### PR TITLE
fix: update endpoints, add recaptcha to complete-registration

### DIFF
--- a/src/components/account-creation-form.js
+++ b/src/components/account-creation-form.js
@@ -71,6 +71,7 @@ const InnerCreateAccountForm = ({
     recaptchaSite,
     recaptchaRef,
     recaptchaError,
+    selfRegistrationNoRecaptcha,
 }) => {
     const isRequired = getIsRequired(uiLocale)
     return (
@@ -152,7 +153,7 @@ const InnerCreateAccountForm = ({
                         />
                     )}
                 </AccountFormSection>
-                {recaptchaSite && (
+                {!selfRegistrationNoRecaptcha && (
                     <AccountFormSection>
                         <ReCAPTCHA
                             ref={recaptchaRef}
@@ -185,6 +186,7 @@ InnerCreateAccountForm.propTypes = {
     recaptchaError: PropTypes.bool,
     recaptchaRef: PropTypes.node,
     recaptchaSite: PropTypes.string,
+    selfRegistrationNoRecaptcha: PropTypes.bool,
     uiLocale: PropTypes.string,
 }
 
@@ -199,8 +201,13 @@ export const CreateAccountForm = ({
     recaptchaError,
 }) => {
     // depends on https://dhis2.atlassian.net/browse/DHIS2-14615
-    const { applicationTitle, uiLocale, emailConfigured, recaptchaSite } =
-        useLoginConfig()
+    const {
+        applicationTitle,
+        uiLocale,
+        emailConfigured,
+        recaptchaSite,
+        selfRegistrationNoRecaptcha,
+    } = useLoginConfig()
 
     useEffect(() => {
         // we should scroll top top of the page when an error is registered, so user sees this
@@ -297,6 +304,9 @@ export const CreateAccountForm = ({
                                 recaptchaSite={recaptchaSite}
                                 recaptchaRef={recaptchaRef}
                                 recaptchaError={recaptchaError}
+                                selfRegistrationNoRecaptcha={
+                                    selfRegistrationNoRecaptcha
+                                }
                             />
                         )}
                     </ReactFinalForm.Form>

--- a/src/pages/create-account.js
+++ b/src/pages/create-account.js
@@ -11,13 +11,13 @@ import { useGetErrorIfNotAllowed } from '../hooks/index.js'
 import { useLoginConfig } from '../providers/index.js'
 
 const selfRegisterMutation = {
-    resource: 'auth/register',
+    resource: 'auth/registration',
     type: 'create',
     data: (data) => data,
 }
 
 const CreateAccountFormWrapper = () => {
-    const { recaptchaSite } = useLoginConfig()
+    const { selfRegistrationNoRecaptcha } = useLoginConfig()
     const recaptchaRef = useRef()
     const [recaptchaError, setRecaptchaError] = useState(false)
     const [selfRegister, { loading, fetching, error, data }] =
@@ -25,17 +25,17 @@ const CreateAccountFormWrapper = () => {
 
     const handleSelfRegister = (values) => {
         setRecaptchaError(false)
-        const gRecaptchaResponse = recaptchaSite
-            ? recaptchaRef.current.getValue()
-            : null
-        if (recaptchaSite && !gRecaptchaResponse) {
+        const gRecaptchaResponse = selfRegistrationNoRecaptcha
+            ? null
+            : recaptchaRef.current.getValue()
+        if (!selfRegistrationNoRecaptcha && !gRecaptchaResponse) {
             setRecaptchaError(true)
             return
         }
         selfRegister(
-            recaptchaSite
-                ? { ...values, 'g-recaptcha-response': gRecaptchaResponse }
-                : values
+            selfRegistrationNoRecaptcha
+                ? values
+                : { ...values, 'g-recaptcha-response': gRecaptchaResponse }
         )
     }
     return (


### PR DESCRIPTION
This PR:
- updates the names of the endpoints (from api/auth/completeRegistration to api/invite and from api/registration to api/register) [names changed by backend team]
- adds recaptcha on the complete-registration (invite confirmation) form
- updates logic to use `selfRegistrationNoRecaptcha` from api/loginConfig to determine whether recaptcha should be required / recaptcha value should be sent in payload