### PR TITLE
fix: update app name to match the bundled apps in core

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -1,7 +1,7 @@
 const config = {
     id: '88723e2b-aec4-4051-87a5-12e06e9446ae',
     type: 'login_app',
-    name: 'login-app',
+    name: 'login',
     title: 'Login app',
     description: 'Core app for the login page of DHIS2',
     coreApp: true,


### PR DESCRIPTION
the app name needs to match [the name maintained](https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-api/src/main/java/org/hisp/dhis/appmanager/AppManager.java#L70) in DHIS2 core for bundled core apps.