### PR TITLE
fix: keep button disabled before redirect [DHIS2-17160]

### DIFF
--- a/src/hooks/useLogin.js
+++ b/src/hooks/useLogin.js
@@ -56,13 +56,7 @@ export const useLogin = () => {
 
             if (response.loginStatus === LOGIN_STATUSES.success) {
                 const redirectString = getRedirectString({ response, baseUrl })
-                try {
-                    window.location.href = redirectString
-                } catch (e) {
-                    // if redirect fails, allow users to try again
-                    console.error(e)
-                    setLoginStatus(null)
-                }
+                window.location.href = redirectString
             }
         },
         onError: (e) => {


### PR DESCRIPTION
This PR addresses the following issue: [DHIS2-17160](https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-17160)

Updates the logic in the useLogin hook
- to return "loading: true" if either the mutation is loading _or_ if the login status is SUCCESS (and we are waiting on the redirect). This keeps the login button disabled while the code for redirect is processing.
- adds an app-internal status (success2fa) to distinguish when the app has come back as success after having a 2fa required. Without this status, there could be UI flicker of on inappropriate error notification about required 2fa before the redirect completed.

How this now looks (I have put in 1000ms wait for illustration purposes below):

**Without 2fa**
![login_redirect](https://github.com/dhis2/login-app/assets/18490902/d7a61f75-4f8f-405b-81d7-dc67d61289bf)

**With 2fa**
![login_redirect_2fa](https://github.com/dhis2/login-app/assets/18490902/d34e99e4-d61f-4440-add7-2dae774a10a9)



[DHIS2-17160]: https://dhis2.atlassian.net/browse/DHIS2-17160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ