### PR TITLE
fix: remove app from title

### DIFF
--- a/d2.config.js
+++ b/d2.config.js
@@ -2,7 +2,7 @@ const config = {
     id: '88723e2b-aec4-4051-87a5-12e06e9446ae',
     type: 'login_app',
     name: 'login',
-    title: 'Login app',
+    title: 'Login',
     description: 'Core app for the login page of DHIS2',
     coreApp: true,
     minDHIS2Version: '2.41',


### PR DESCRIPTION
Updates title to `Login` rather than `Login app`