### PR TITLE
chore: add unit tests [DHIS2-16968]

### DIFF
--- a/.github/workflows/dhis2-verify-app.yml
+++ b/.github/workflows/dhis2-verify-app.yml
@@ -103,7 +103,7 @@ jobs:
               run: yarn d2-app-scripts i18n generate
 
             - name: Test
-              run: yarn test
+              run: yarn test --coverage
 
             - name: Upload coverage reports to Codecov
               uses: codecov/codecov-action@v4.0.1

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+    setupFilesAfterEnv: ['<rootDir>/src/test-utils/setup-tests.js'],
+    collectCoverageFrom: ['src/**/*.{js,jsx}'],
+    coveragePathIgnorePatterns: ['/node_modules/', '/src/locales/'],
+    moduleNameMapper: {
+        '\\.css$': 'identity-obj-proxy',
+    },
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "@dhis2/cli-style": "^10.5.1",
         "@testing-library/jest-dom": "^6.4.5",
         "@testing-library/react-hooks": "^8.0.1",
+        "@testing-library/user-event": "^14.5.2",
         "enzyme": "^3.11.0",
         "enzyme-adapter-react-16": "^1.15.8",
         "jest-extended": "^4.0.2"

--- a/package.json
+++ b/package.json
@@ -16,7 +16,12 @@
     },
     "devDependencies": {
         "@dhis2/cli-app-scripts": "10.6.0-alpha.3",
-        "@dhis2/cli-style": "^10.5.1"
+        "@dhis2/cli-style": "^10.5.1",
+        "@testing-library/jest-dom": "^6.4.5",
+        "@testing-library/react-hooks": "^8.0.1",
+        "enzyme": "^3.11.0",
+        "enzyme-adapter-react-16": "^1.15.8",
+        "jest-extended": "^4.0.2"
     },
     "jest": {
         "collectCoverageFrom": [

--- a/src/app.js
+++ b/src/app.js
@@ -112,18 +112,14 @@ const AppContent = () => {
     return <>{parse(sanitizeMainHTML(html), options)}</>
 }
 
-const App = () => {
-    return (
-        <>
-            <HashRouter>
-                <LoginConfigProvider>
-                    <CssReset />
-                    <CssVariables colors spacers theme elevations />
-                    <AppContent />
-                </LoginConfigProvider>
-            </HashRouter>
-        </>
-    )
-}
+const App = () => (
+    <HashRouter>
+        <LoginConfigProvider>
+            <CssReset />
+            <CssVariables colors spacers theme elevations />
+            <AppContent />
+        </LoginConfigProvider>
+    </HashRouter>
+)
 
 export default App

--- a/src/app.js
+++ b/src/app.js
@@ -98,7 +98,7 @@ const options = {
     },
 }
 
-const AppContent = () => {
+export const AppContent = () => {
     const { loginPageLayout, loginPageTemplate } = useLoginConfig()
     let html
     if (loginPageLayout === 'SIDEBAR') {

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -1,8 +1,8 @@
-import { render, screen } from '@testing-library/react'
+import { screen } from '@testing-library/react'
 import React from 'react'
-import { MemoryRouter } from 'react-router-dom'
 import { AppContent } from './app.js'
 import { useLoginConfig } from './providers/use-login-config.js'
+import { renderWithRouter } from './test-utils/index.js'
 
 jest.mock('./components/customizable-elements.js', () => ({
     ...jest.requireActual('./components/customizable-elements.js'),
@@ -29,9 +29,6 @@ jest.mock('./templates/index.js', () => ({
     sidebar: '<div>SIDEBAR TEMPLATE</div>',
 }))
 
-const renderWithRouter = (component) =>
-    render(<MemoryRouter>{component}</MemoryRouter>)
-
 describe('AppContent', () => {
     afterEach(() => {
         jest.clearAllMocks()
@@ -43,45 +40,45 @@ describe('AppContent', () => {
     })
 
     it('loads sidebar template if loginPageLayout is SIDEBAR', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'SIDEBAR',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(screen.getByText('SIDEBAR TEMPLATE')).toBeInTheDocument()
     })
 
     it('loads standard template if loginPageLayout is CUSTOM and loginPageTemplate is null', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: null,
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(screen.getByText('STANDARD TEMPLATE')).toBeInTheDocument()
     })
 
     it('loads custom loginPageTemplate if loginPageLayout is CUSTOM and loginPageTemplate is not null', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div>CUSTOM TEMPLATE</div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(screen.getByText('CUSTOM TEMPLATE')).toBeInTheDocument()
     })
 
     it('replaces application-title element with ApplicationTitle component ', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div id="application-title"></div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(screen.getByText('MOCK_APPLICATION_TITLE')).toBeInTheDocument()
     })
 
     it('replaces application-introduction element with ApplicationDescription component ', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div id="application-introduction"></div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(
             screen.getByText('MOCK_APPLICATION_DESCRIPTION')
@@ -89,55 +86,55 @@ describe('AppContent', () => {
     })
 
     it('replaces application-title element with ApplicationDescription component ', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div id="application-title"></div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(screen.getByText('MOCK_APPLICATION_TITLE')).toBeInTheDocument()
     })
 
     it('replaces application-title element with ApplicationDescription component ', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div id="application-title"></div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(screen.getByText('MOCK_APPLICATION_TITLE')).toBeInTheDocument()
     })
 
     it('replaces flag element with Flag component ', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div id="flag"></div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(screen.getByText('MOCK_FLAG')).toBeInTheDocument()
     })
 
     it('replaces logo element with Logo component ', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div id="logo"></div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(screen.getByText('MOCK_LOGO')).toBeInTheDocument()
     })
 
     it('replaces powered-by element with PoweredBy component ', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div id="powered-by"></div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(screen.getByText('MOCK_POWERED_BY')).toBeInTheDocument()
     })
 
     it('replaces application-left-footer element with ApplicationLeftFooter component ', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div id="application-left-footer"></div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(
             screen.getByText('MOCK_APPLICATION_LEFT_FOOTER')
@@ -145,10 +142,10 @@ describe('AppContent', () => {
     })
 
     it('replaces application-right-footer element with ApplicationRightFooter component ', () => {
-        useLoginConfig.mockImplementationOnce(() => ({
+        useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',
             loginPageTemplate: '<div id="application-right-footer"></div>',
-        }))
+        })
         renderWithRouter(<AppContent />)
         expect(
             screen.getByText('MOCK_APPLICATION_RIGHT_FOOTER')

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -1,15 +1,157 @@
-import { CustomDataProvider } from '@dhis2/app-runtime'
+import { render, screen } from '@testing-library/react'
 import React from 'react'
-import ReactDOM from 'react-dom'
-import App from './app.js'
+import { MemoryRouter } from 'react-router-dom'
+import { AppContent } from './app.js'
+import { useLoginConfig } from './providers/use-login-config.js'
 
-it('renders without crashing', () => {
-    const div = document.createElement('div')
-    ReactDOM.render(
-        <CustomDataProvider>
-            <App />
-        </CustomDataProvider>,
-        div
-    )
-    ReactDOM.unmountComponentAtNode(div)
+jest.mock('./components/customizable-elements.js', () => ({
+    ...jest.requireActual('./components/customizable-elements.js'),
+    LanguageSelect: () => <div>MOCK_LANGUAGE_SELECT</div>,
+    ApplicationTitle: () => <div>MOCK_APPLICATION_TITLE</div>,
+    ApplicationDescription: () => <div>MOCK_APPLICATION_DESCRIPTION</div>,
+    Flag: () => <div>MOCK_FLAG</div>,
+    Logo: () => <div>MOCK_LOGO</div>,
+    ApplicationLeftFooter: () => <div>MOCK_APPLICATION_LEFT_FOOTER</div>,
+    ApplicationRightFooter: () => <div>MOCK_APPLICATION_RIGHT_FOOTER</div>,
+    PoweredByDHIS2: () => <div>MOCK_POWERED_BY</div>,
+}))
+
+jest.mock('./providers/use-login-config.js', () => ({
+    useLoginConfig: jest.fn(() => ({
+        loginPageLayout: 'DEFAULT',
+        loginPageTemplate: null,
+    })),
+}))
+
+jest.mock('./templates/index.js', () => ({
+    __esModule: true,
+    standard: '<div>STANDARD TEMPLATE</div>',
+    sidebar: '<div>SIDEBAR TEMPLATE</div>',
+}))
+
+const renderWithRouter = (component) =>
+    render(<MemoryRouter>{component}</MemoryRouter>)
+
+describe('AppContent', () => {
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('loads standard template if loginPageLayout is DEFAULT', () => {
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('STANDARD TEMPLATE')).toBeInTheDocument()
+    })
+
+    it('loads sidebar template if loginPageLayout is SIDEBAR', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'SIDEBAR',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('SIDEBAR TEMPLATE')).toBeInTheDocument()
+    })
+
+    it('loads standard template if loginPageLayout is CUSTOM and loginPageTemplate is null', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: null,
+        }))
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('STANDARD TEMPLATE')).toBeInTheDocument()
+    })
+
+    it('loads custom loginPageTemplate if loginPageLayout is CUSTOM and loginPageTemplate is not null', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div>CUSTOM TEMPLATE</div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('CUSTOM TEMPLATE')).toBeInTheDocument()
+    })
+
+    it('replaces application-title element with ApplicationTitle component ', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div id="application-title"></div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('MOCK_APPLICATION_TITLE')).toBeInTheDocument()
+    })
+
+    it('replaces application-introduction element with ApplicationDescription component ', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div id="application-introduction"></div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(
+            screen.getByText('MOCK_APPLICATION_DESCRIPTION')
+        ).toBeInTheDocument()
+    })
+
+    it('replaces application-title element with ApplicationDescription component ', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div id="application-title"></div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('MOCK_APPLICATION_TITLE')).toBeInTheDocument()
+    })
+
+    it('replaces application-title element with ApplicationDescription component ', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div id="application-title"></div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('MOCK_APPLICATION_TITLE')).toBeInTheDocument()
+    })
+
+    it('replaces flag element with Flag component ', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div id="flag"></div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('MOCK_FLAG')).toBeInTheDocument()
+    })
+
+    it('replaces logo element with Logo component ', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div id="logo"></div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('MOCK_LOGO')).toBeInTheDocument()
+    })
+
+    it('replaces powered-by element with PoweredBy component ', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div id="powered-by"></div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('MOCK_POWERED_BY')).toBeInTheDocument()
+    })
+
+    it('replaces application-left-footer element with ApplicationLeftFooter component ', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div id="application-left-footer"></div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(
+            screen.getByText('MOCK_APPLICATION_LEFT_FOOTER')
+        ).toBeInTheDocument()
+    })
+
+    it('replaces application-right-footer element with ApplicationRightFooter component ', () => {
+        useLoginConfig.mockImplementationOnce(() => ({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '<div id="application-right-footer"></div>',
+        }))
+        renderWithRouter(<AppContent />)
+        expect(
+            screen.getByText('MOCK_APPLICATION_RIGHT_FOOTER')
+        ).toBeInTheDocument()
+    })
 })

--- a/src/components/__tests__/back-to-login-button.test.js
+++ b/src/components/__tests__/back-to-login-button.test.js
@@ -1,0 +1,48 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { BackToLoginButton } from '../back-to-login-button.js'
+
+const MainPage = () => <div>MAIN PAGE</div>
+const OtherPage = ({ children }) => <>{children}</>
+
+OtherPage.propTypes = {
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]),
+}
+
+const Wrapper = ({ children }) => (
+    <MemoryRouter initialEntries={['/other']}>
+        <Routes>
+            <Route path="/" element={<MainPage />} />
+            <Route path="/other" element={<OtherPage>{children}</OtherPage>} />
+        </Routes>
+    </MemoryRouter>
+)
+
+Wrapper.propTypes = {
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]),
+}
+
+describe('BackToLoginButton', () => {
+    it('redirects to main page when clicked', () => {
+        render(
+            <Wrapper>
+                <BackToLoginButton />
+            </Wrapper>
+        )
+        expect(screen.queryByText('MAIN PAGE')).toBe(null)
+        fireEvent.click(
+            screen.getByRole('button', {
+                name: /back to log in/i,
+            })
+        )
+        expect(screen.getByText('MAIN PAGE')).not.toBe(null)
+    })
+})

--- a/src/components/__tests__/customizable-elements.test.js
+++ b/src/components/__tests__/customizable-elements.test.js
@@ -1,8 +1,16 @@
+import i18n from '@dhis2/d2-i18n'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
 import { useLoginConfig } from '../../providers/use-login-config.js'
-import { LanguageSelect } from '../customizable-elements.js'
+import {
+    ApplicationDescription,
+    ApplicationLeftFooter,
+    ApplicationRightFooter,
+    ApplicationTitle,
+    LanguageSelect,
+    PoweredByDHIS2,
+} from '../customizable-elements.js'
 
 const mockRefreshOnTranslation = jest.fn()
 
@@ -45,5 +53,65 @@ describe('LanguageSelect', () => {
         await user.click(screen.getByText('Wolof làkk — Wolof'))
         expect(mockRefreshOnTranslation).toHaveBeenCalled()
         expect(mockRefreshOnTranslation).toHaveBeenCalledWith({ locale: 'wo' })
+    })
+})
+
+describe('ApplicationTitle', () => {
+    it('shows value from useLoginConfig', () => {
+        useLoginConfig.mockReturnValue({
+            applicationTitle: 'Little Red Riding Hood',
+        })
+        render(<ApplicationTitle />)
+        expect(screen.getByText('Little Red Riding Hood')).toBeInTheDocument()
+    })
+})
+
+describe('ApplicationDescription', () => {
+    it('shows value from useLoginConfig', () => {
+        useLoginConfig.mockReturnValue({
+            applicationDescription:
+                'Wolf eats grandmother; grandaugther gets house',
+        })
+        render(<ApplicationDescription />)
+        expect(
+            screen.getByText('Wolf eats grandmother; grandaugther gets house')
+        ).toBeInTheDocument()
+    })
+})
+
+describe('ApplicationLeftFooter', () => {
+    it('shows value from useLoginConfig', () => {
+        useLoginConfig.mockReturnValue({
+            applicationLeftSideFooter: 'This way home',
+        })
+        render(<ApplicationLeftFooter />)
+        expect(screen.getByText('This way home')).toBeInTheDocument()
+    })
+})
+
+describe('ApplicationRightFooter', () => {
+    it('shows value from useLoginConfig', () => {
+        useLoginConfig.mockReturnValue({
+            applicationRightSideFooter: "That way to grandma's",
+        })
+        render(<ApplicationRightFooter />)
+        expect(screen.getByText("That way to grandma's")).toBeInTheDocument()
+    })
+})
+
+describe('PoweredByDHIS2', () => {
+    it('displays in translation', () => {
+        useLoginConfig.mockReturnValue({
+            uiLocale: 'id',
+        })
+        const i18Spy = jest
+            .spyOn(i18n, 't')
+            .mockReturnValue('Dipersembahkan oleh DHIS2')
+        render(<PoweredByDHIS2 />)
+        expect(i18Spy).toHaveBeenCalled()
+        expect(i18Spy).toHaveBeenCalledWith('Powered by DHIS2', { lng: 'id' })
+        expect(
+            screen.getByText('Dipersembahkan oleh DHIS2')
+        ).toBeInTheDocument()
     })
 })

--- a/src/components/__tests__/customizable-elements.test.js
+++ b/src/components/__tests__/customizable-elements.test.js
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { useLoginConfig } from '../../providers/use-login-config.js'
+import { LanguageSelect } from '../customizable-elements.js'
+
+const mockRefreshOnTranslation = jest.fn()
+
+const LANGUAGE_SELECT_DEFAULT_VALUES = {
+    localesUI: [
+        { locale: 'en', displayName: 'English', name: 'English' },
+        { locale: 'fr', displayName: 'French', name: 'français' },
+        { locale: 'cy', displayName: 'Welsh', name: 'Cymraeg' },
+        { locale: 'dz', displayName: 'Dzongkha', name: 'རྫོང་ཁ་' },
+        { locale: 'nv', displayName: 'Navajo', name: 'Diné bizaad' },
+        { locale: 'wo', displayName: 'Wolof', name: 'Wolof làkk' },
+    ],
+    uiLocale: 'cy',
+    systemLocale: 'en',
+}
+
+jest.mock('../../providers/use-login-config.js', () => ({
+    useLoginConfig: jest.fn(),
+}))
+
+describe('LanguageSelect', () => {
+    it('displays uiLocale as selection', () => {
+        useLoginConfig.mockReturnValue({
+            ...LANGUAGE_SELECT_DEFAULT_VALUES,
+            refreshOnTranslation: mockRefreshOnTranslation,
+        })
+        render(<LanguageSelect />)
+        expect(screen.getByText('Cymraeg — Welsh')).toBeInTheDocument()
+    })
+
+    it('calls refreshOnTranslation', async () => {
+        const user = userEvent.setup()
+        useLoginConfig.mockReturnValue({
+            ...LANGUAGE_SELECT_DEFAULT_VALUES,
+            refreshOnTranslation: mockRefreshOnTranslation,
+        })
+        render(<LanguageSelect />)
+
+        await user.click(screen.getByText('Cymraeg — Welsh'))
+        await user.click(screen.getByText('Wolof làkk — Wolof'))
+        expect(mockRefreshOnTranslation).toHaveBeenCalled()
+        expect(mockRefreshOnTranslation).toHaveBeenCalledWith({ locale: 'wo' })
+    })
+})

--- a/src/components/__tests__/login-links.test.js
+++ b/src/components/__tests__/login-links.test.js
@@ -1,0 +1,80 @@
+import { screen } from '@testing-library/react'
+import React from 'react'
+import { useLoginConfig } from '../../providers/use-login-config.js'
+import { renderWithRouter } from '../../test-utils/render-with-router.js'
+import { LoginLinks } from '../login-links.js'
+
+jest.mock('../../providers/use-login-config.js', () => ({
+    useLoginConfig: jest.fn(),
+}))
+
+describe('LoginLinks', () => {
+    it('shows link to reset password if allowAccountRecovery and emailConfigured', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+            selfRegistrationEnabled: true,
+        })
+        renderWithRouter(<LoginLinks />)
+        expect(screen.getByText(/forgot password/i)).toBeInTheDocument()
+        expect(
+            screen.getByText(/forgot password/i).closest('a')
+        ).toHaveAttribute('href', '/reset-password')
+    })
+
+    it('shows link to reset password if allowAccountRecovery and emailConfigured with username if passed', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+            selfRegistrationEnabled: true,
+        })
+        renderWithRouter(<LoginLinks formUserName="Askepott" />)
+        expect(screen.getByText(/forgot password/i)).toBeInTheDocument()
+        expect(
+            screen.getByText(/forgot password/i).closest('a')
+        ).toHaveAttribute('href', '/reset-password?username=Askepott')
+    })
+
+    it('does not show link to reset password if allowAccountRecovery false', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: false,
+            emailConfigured: true,
+            selfRegistrationEnabled: true,
+        })
+        renderWithRouter(<LoginLinks />)
+        expect(screen.queryByText(/forgot password/i)).toBe(null)
+    })
+
+    it('does not show link to reset password if emailConfigured false', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: false,
+            selfRegistrationEnabled: true,
+        })
+        renderWithRouter(<LoginLinks />)
+        expect(screen.queryByText(/forgot password/i)).toBe(null)
+    })
+
+    it('shows link to create account if selfRegistrationEnabled', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+            selfRegistrationEnabled: true,
+        })
+        renderWithRouter(<LoginLinks />)
+        expect(screen.getByText(/create an account/i)).toBeInTheDocument()
+        expect(
+            screen.getByText(/create an account/i).closest('a')
+        ).toHaveAttribute('href', '/create-account')
+    })
+
+    it('does not show link to create account if selfRegistrationEnabled is false', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+            selfRegistrationEnabled: false,
+        })
+        renderWithRouter(<LoginLinks />)
+        expect(screen.queryByText(/create an account/i)).toBe(null)
+    })
+})

--- a/src/components/form-container.js
+++ b/src/components/form-container.js
@@ -10,7 +10,7 @@ export const FormContainer = ({ children, title, variableWidth }) => (
                 : styles.formContainer
         }
     >
-        {title && <p className={styles.formTitle}>{title}</p>}
+        {title && <h3 className={styles.formTitle}>{title}</h3>}
         {children}
     </div>
 )

--- a/src/components/login-links.js
+++ b/src/components/login-links.js
@@ -18,7 +18,13 @@ export const LoginLinks = ({ formUserName }) => {
             <div className={styles.links}>
                 {allowAccountRecovery && emailConfigured && (
                     <span>
-                        <Link to={`/reset-password?username=${formUserName}`}>
+                        <Link
+                            to={
+                                formUserName
+                                    ? `/reset-password?username=${formUserName}`
+                                    : `/reset-password`
+                            }
+                        >
                             {i18n.t('Forgot password?', { lng: uiLocale })}
                         </Link>
                     </span>

--- a/src/helpers/__tests__/handleHTML.test.js
+++ b/src/helpers/__tests__/handleHTML.test.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import { convertHTML, sanitizeMainHTML, removeHTMLTags } from '../handleHTML.js'
+
+describe('sanitizeMainHTML', () => {
+    it('removes <script> tags', () => {
+        const before =
+            '<div>hello</div><div>another</div><script>maliciousFunction()</script>'
+        const after = '<div>hello</div><div>another</div>'
+        expect(sanitizeMainHTML(before)).toBe(after)
+    })
+    it('keeps <style> tags', () => {
+        const before =
+            '<head><style>myCss{}></style></head><body><div>hello</div><div>another</div><script>maliciousFunction()</script></body>'
+        const after =
+            '<style>myCss{}></style><div>hello</div><div>another</div>'
+        expect(sanitizeMainHTML(before)).toBe(after)
+    })
+    it('fixes missing closing tags', () => {
+        const before = '<div><p>okay</p><p>not okay</div>'
+        const after = '<div><p>okay</p><p>not okay</p></div>'
+        expect(sanitizeMainHTML(before)).toBe(after)
+    })
+})
+
+describe('convertHTML', () => {
+    it('converts into an array of HTML elements', () => {
+        const before = '<div>one</div><div><p>some content</p></div>'
+        const after = [
+            <div key="0">one</div>,
+            <div key="1">
+                <p>some content</p>
+            </div>,
+        ]
+        expect(convertHTML(before)).toEqual(after)
+    })
+})
+
+describe('removeHTMLTags', () => {
+    it('removes html tag from text', () => {
+        const before =
+            'My <strong>wonderful</strong> <a href="some_link">DHIS2 instance</a>'
+        const after = 'My wonderful DHIS2 instance'
+        expect(removeHTMLTags(before)).toBe(after)
+    })
+})
+
+// export const removeHTMLTags = (text) => text.replace(/(<([^>]+)>)/gi, '')
+
+// export const sanitizeMainHTML = (html) =>
+//     DOMPurify.sanitize(html, {
+//         FORCE_BODY: true,
+//         ADD_TAGS: ['style', 'iframe'],
+//     })
+
+// export const convertHTML = (html) => parse(DOMPurify.sanitize(html))

--- a/src/helpers/__tests__/handleHTML.test.js
+++ b/src/helpers/__tests__/handleHTML.test.js
@@ -43,13 +43,3 @@ describe('removeHTMLTags', () => {
         expect(removeHTMLTags(before)).toBe(after)
     })
 })
-
-// export const removeHTMLTags = (text) => text.replace(/(<([^>]+)>)/gi, '')
-
-// export const sanitizeMainHTML = (html) =>
-//     DOMPurify.sanitize(html, {
-//         FORCE_BODY: true,
-//         ADD_TAGS: ['style', 'iframe'],
-//     })
-
-// export const convertHTML = (html) => parse(DOMPurify.sanitize(html))

--- a/src/helpers/__tests__/redirectHelpers.test.js
+++ b/src/helpers/__tests__/redirectHelpers.test.js
@@ -1,0 +1,44 @@
+import { getRedirectString } from '../../helpers/redirectHelpers.js'
+
+describe('getRedirectString', () => {
+    const ACTUAL_ENVIRONMENT_VARIABLES = process.env
+
+    beforeEach(() => {
+        jest.resetModules()
+        process.env = { ...ACTUAL_ENVIRONMENT_VARIABLES }
+    })
+
+    afterAll(() => {
+        process.env = ACTUAL_ENVIRONMENT_VARIABLES
+    })
+
+    it('returns redirect string if defined', () => {
+        // Set the variables
+        process.env.NODE_ENV = 'prod'
+        const redirectString = getRedirectString({
+            response: { redirectUrl: 'toHere' },
+            baseUrl: 'path/',
+        })
+        expect(redirectString).toBe('toHere')
+    })
+
+    it('returns baseurl if redirect string is not defined', () => {
+        // Set the variables
+        process.env.NODE_ENV = 'prod'
+        const redirectString = getRedirectString({
+            response: {},
+            baseUrl: 'path/',
+        })
+        expect(redirectString).toBe('path/')
+    })
+
+    it('returns base url + redirectUrl if in development mode', () => {
+        // Set the variables
+        process.env.NODE_ENV = 'development'
+        const redirectString = getRedirectString({
+            response: { redirectUrl: 'toHere' },
+            baseUrl: 'path/',
+        })
+        expect(redirectString).toBe('path/toHere')
+    })
+})

--- a/src/helpers/__tests__/validators.test.js
+++ b/src/helpers/__tests__/validators.test.js
@@ -6,7 +6,7 @@ describe('checkIsLoginFormValid', () => {
             checkIsLoginFormValid({ username: 'some', password: 'thing' })
         ).toBe(true)
     }),
-        it('returns false if username and password do not values', () => {
+        it('returns false if username and password do not have values', () => {
             expect(
                 checkIsLoginFormValid({ username: null, password: null })
             ).toBe(false)

--- a/src/helpers/__tests__/validators.test.js
+++ b/src/helpers/__tests__/validators.test.js
@@ -1,0 +1,14 @@
+import { checkIsLoginFormValid } from '../validators.js'
+
+describe('checkIsLoginFormValid', () => {
+    it('returns true if username and password have values', () => {
+        expect(
+            checkIsLoginFormValid({ username: 'some', password: 'thing' })
+        ).toBe(true)
+    }),
+        it('returns false if username and password do not values', () => {
+            expect(
+                checkIsLoginFormValid({ username: null, password: null })
+            ).toBe(false)
+        })
+})

--- a/src/helpers/handleHTML.js
+++ b/src/helpers/handleHTML.js
@@ -1,12 +1,6 @@
 import * as DOMPurify from 'dompurify'
 import parse from 'html-react-parser'
 
-export const unescapeHTML = (html) => {
-    const parser = new DOMParser()
-    const dom = parser.parseFromString(html, 'text/html')
-    return dom?.body?.textContent
-}
-
 export const removeHTMLTags = (text) => text.replace(/(<([^>]+)>)/gi, '')
 
 export const sanitizeMainHTML = (html) =>

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,7 +1,3 @@
-export { checkIsFormValid, getIsRequired } from './validators.js'
-export {
-    convertHTML,
-    removeHTMLTags,
-    sanitizeMainHTML,
-    unescapeHTML,
-} from './handleHTML.js'
+export { checkIsLoginFormValid, getIsRequired } from './validators.js'
+export { convertHTML, removeHTMLTags, sanitizeMainHTML } from './handleHTML.js'
+export { redirectTo, getRedirectString } from './redirectHelpers.js'

--- a/src/helpers/redirectHelpers.js
+++ b/src/helpers/redirectHelpers.js
@@ -1,0 +1,10 @@
+export const getRedirectString = ({ response, baseUrl }) => {
+    if (process.env.NODE_ENV === 'development') {
+        return baseUrl + response?.redirectUrl
+    }
+    return response.redirectUrl ? `${response.redirectUrl}` : baseUrl
+}
+
+export const redirectTo = (redirectDestination) => {
+    window.location.href = redirectDestination
+}

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -3,7 +3,18 @@ import i18n from '@dhis2/d2-i18n'
 export const getIsRequired = (uiLocale) => (val) =>
     val ? undefined : i18n.t('This field is required', { lng: uiLocale })
 
-export const checkIsFormValid = (validatorsByField) => {
+export const checkIsLoginFormValid = (values) => {
+    const isRequired = getIsRequired('en') // 'en' because we do not need the actual translation for validation test
+    const validatorsByField = {
+        username: {
+            value: values.username,
+            validator: isRequired,
+        },
+        password: {
+            value: values.password,
+            validator: isRequired,
+        },
+    }
     for (const key of Object.keys(validatorsByField)) {
         if (validatorsByField[key].validator(validatorsByField[key].value)) {
             return false

--- a/src/hooks/__tests__/useGetErrorIfNotAllowed.test.js
+++ b/src/hooks/__tests__/useGetErrorIfNotAllowed.test.js
@@ -1,0 +1,39 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { useLoginConfig } from '../../providers/use-login-config.js'
+import { useGetErrorIfNotAllowed } from '../useGetErrorIfNotAllowed.js'
+
+jest.mock('../../providers/use-login-config.js', () => ({
+    useLoginConfig: jest.fn(),
+}))
+
+describe('useGetErrorIfNotAllowed', () => {
+    it('returns notAllowed:false if all properties true in useLoginConfig', () => {
+        useLoginConfig.mockReturnValue({ testPropOne: true, testPropTwo: true })
+        const { result } = renderHook(() =>
+            useGetErrorIfNotAllowed(['testPropOne', 'testPropTwo'])
+        )
+        expect(result.current).toHaveProperty('notAllowed')
+        expect(result.current.notAllowed).toBe(false)
+    })
+
+    it('returns notAllowed:true if some properties false in useLoginConfig', () => {
+        useLoginConfig.mockReturnValue({
+            testPropOne: true,
+            testPropTwo: false,
+        })
+        const { result } = renderHook(() =>
+            useGetErrorIfNotAllowed(['testPropOne', 'testPropTwo'])
+        )
+        expect(result.current).toHaveProperty('notAllowed')
+        expect(result.current.notAllowed).toBe(true)
+    })
+
+    it('returns notAllowed:true if some properties null in useLoginConfig', () => {
+        useLoginConfig.mockReturnValue({ testPropOne: true })
+        const { result } = renderHook(() =>
+            useGetErrorIfNotAllowed(['testPropOne', 'testPropTwo'])
+        )
+        expect(result.current).toHaveProperty('notAllowed')
+        expect(result.current.notAllowed).toBe(true)
+    })
+})

--- a/src/hooks/__tests__/useLogin.test.js
+++ b/src/hooks/__tests__/useLogin.test.js
@@ -43,21 +43,6 @@ describe('useLogin', () => {
         expect(redirectTo).toHaveBeenCalled()
     })
 
-    it('redirects after receiving SUCCESS', async () => {
-        useDataMutation.mockImplementation((mutation, options) => [
-            () => {
-                options.onComplete({ loginStatus: 'SUCCESS' })
-            },
-            { loading: false },
-        ])
-
-        const { result } = renderHook(() => useLogin())
-        expect(result.current.loading).toBe(false)
-        act(() => result.current.login())
-        expect(result.current.loading).toBe(true)
-        expect(redirectTo).toHaveBeenCalled()
-    })
-
     it('sets twoFAVerificationRequired to true first time after receiving INCORRECT_TWO_FACTOR_CODE ', async () => {
         useDataMutation.mockImplementation((mutation, options) => [
             () => {
@@ -71,25 +56,6 @@ describe('useLogin', () => {
         act(() => result.current.login())
         expect(result.current.loading).toBe(false)
         expect(result.current.twoFAVerificationRequired).toBe(true)
-    })
-
-    it('sets twoFAIncorrect to true second time after receiving INCORRECT_TWO_FACTOR_CODE ', async () => {
-        useDataMutation.mockImplementation((mutation, options) => [
-            () => {
-                options.onComplete({ loginStatus: 'INCORRECT_TWO_FACTOR_CODE' })
-            },
-            { loading: false },
-        ])
-
-        const { result } = renderHook(() => useLogin())
-        expect(result.current.loading).toBe(false)
-        act(() => {
-            result.current.login()
-            result.current.login()
-        })
-        expect(result.current.loading).toBe(false)
-        expect(result.current.twoFAVerificationRequired).toBe(true)
-        expect(result.current.twoFAIncorrect).toBe(true)
     })
 
     it('sets twoFAIncorrect to true second time after receiving INCORRECT_TWO_FACTOR_CODE ', async () => {

--- a/src/hooks/__tests__/useLogin.test.js
+++ b/src/hooks/__tests__/useLogin.test.js
@@ -1,0 +1,144 @@
+import { useDataMutation } from '@dhis2/app-runtime'
+import { act, renderHook } from '@testing-library/react-hooks'
+import { redirectTo } from '../../helpers/redirectHelpers.js'
+import { useLogin } from '../useLogin.js'
+
+jest.mock('@dhis2/app-runtime', () => ({
+    useDataMutation: jest.fn(() => [() => {}, { loading: false }]),
+}))
+
+jest.mock('../../helpers/redirectHelpers.js', () => ({
+    redirectTo: jest.fn(() => {}),
+    getRedirectString: jest.fn(() => 'redirect/path'),
+}))
+
+describe('useLogin', () => {
+    it('loads', () => {
+        const { result } = renderHook(() => useLogin())
+        expect(result.current).toHaveProperty('login')
+        expect(typeof result.current.login).toBe('function')
+    })
+
+    it('redirects after receiving SUCCESS', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onComplete({ loginStatus: 'SUCCESS' })
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        act(() => result.current.login())
+        expect(result.current.loading).toBe(true)
+        expect(redirectTo).toHaveBeenCalled()
+    })
+
+    it('sets twoFAVerificationRequired to true first time after receiving INCORRECT_TWO_FACTOR_CODE ', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onComplete({ loginStatus: 'INCORRECT_TWO_FACTOR_CODE' })
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        act(() => result.current.login())
+        expect(result.current.loading).toBe(false)
+        expect(result.current.twoFAVerificationRequired).toBe(true)
+    })
+
+    it('sets twoFAIncorrect to true second time after receiving INCORRECT_TWO_FACTOR_CODE ', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onComplete({ loginStatus: 'INCORRECT_TWO_FACTOR_CODE' })
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        act(() => {
+            result.current.login()
+            result.current.login()
+        })
+        expect(result.current.loading).toBe(false)
+        expect(result.current.twoFAVerificationRequired).toBe(true)
+        expect(result.current.twoFAIncorrect).toBe(true)
+    })
+
+    it('sets twoFAIncorrect to true second time after receiving INCORRECT_TWO_FACTOR_CODE ', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onComplete({ loginStatus: 'INCORRECT_TWO_FACTOR_CODE' })
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        act(() => {
+            result.current.login()
+            result.current.login()
+        })
+        expect(result.current.loading).toBe(false)
+        expect(result.current.twoFAVerificationRequired).toBe(true)
+        expect(result.current.twoFAIncorrect).toBe(true)
+    })
+
+    it('clears information about twoFA status if cancelTwoFA is called ', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onComplete({ loginStatus: 'INCORRECT_TWO_FACTOR_CODE' })
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        act(() => {
+            result.current.login()
+            result.current.login()
+            result.current.cancelTwoFA()
+        })
+        expect(result.current.loading).toBe(false)
+        expect(result.current.twoFAVerificationRequired).toBe(false)
+        expect(result.current.twoFAIncorrect).toBe(false)
+    })
+
+    it('sets twoFANotEnabled to true if INVALID received on login', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onComplete({ loginStatus: 'INVALID' })
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        act(() => {
+            result.current.login()
+        })
+        expect(result.current.loading).toBe(false)
+        expect(result.current.twoFANotEnabled).toBe(true)
+    })
+
+    it('returns error if login fails', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onError(new Error('mock'))
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        expect(result.current.error).toBe(null)
+        act(() => {
+            result.current.login()
+        })
+        expect(result.current.loading).toBe(false)
+        expect(result.current.error).not.toBe(null)
+    })
+})

--- a/src/hooks/__tests__/useLogin.test.js
+++ b/src/hooks/__tests__/useLogin.test.js
@@ -13,10 +13,34 @@ jest.mock('../../helpers/redirectHelpers.js', () => ({
 }))
 
 describe('useLogin', () => {
-    it('loads', () => {
+    it('returns a login function', () => {
         const { result } = renderHook(() => useLogin())
         expect(result.current).toHaveProperty('login')
         expect(typeof result.current.login).toBe('function')
+    })
+
+    it('has a login mutation that points to auth/login', () => {
+        useDataMutation.mockImplementationOnce((mutation) => [
+            mutation.resource,
+            { loading: false },
+        ])
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.login).toBe('auth/login')
+    })
+
+    it('redirects after receiving SUCCESS', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onComplete({ loginStatus: 'SUCCESS' })
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        act(() => result.current.login())
+        expect(result.current.loading).toBe(true)
+        expect(redirectTo).toHaveBeenCalled()
     })
 
     it('redirects after receiving SUCCESS', async () => {

--- a/src/hooks/useGetErrorIfNotAllowed.js
+++ b/src/hooks/useGetErrorIfNotAllowed.js
@@ -6,7 +6,7 @@ export const useGetErrorIfNotAllowed = (requiredSettings) => {
 
     let notAllowed = false
     for (const setting of requiredSettings) {
-        if (loginConfig[setting] === false) {
+        if (!loginConfig[setting]) {
             notAllowed = true
             break
         }

--- a/src/hooks/useLogin.js
+++ b/src/hooks/useLogin.js
@@ -1,5 +1,6 @@
 import { useDataMutation } from '@dhis2/app-runtime'
 import { useState } from 'react'
+import { redirectTo, getRedirectString } from '../helpers/index.js'
 import { useLoginConfig } from '../providers/index.js'
 
 const LOGIN_STATUSES = {
@@ -13,15 +14,6 @@ const invalidTWOFA = [
     LOGIN_STATUSES.incorrect2fa,
     LOGIN_STATUSES.secondAttempt2fa,
 ]
-
-// To be updated based on https://dhis2.atlassian.net/browse/DHIS2-14613
-
-const getRedirectString = ({ response, baseUrl }) => {
-    if (process.env.NODE_ENV === 'development') {
-        return baseUrl + response?.redirectUrl
-    }
-    return response.redirectUrl ? `${response.redirectUrl}` : baseUrl
-}
 
 const loginMutation = {
     resource: 'auth/login',
@@ -42,27 +34,35 @@ export const useLogin = () => {
         setLoginStatus(null)
     }
 
+    const handleSuccessfulLogin = (response) => {
+        setError(null)
+        // we need to distinguish between incorrect 2fa on second attempt
+        setLoginStatus((prev) =>
+            invalidTWOFA.includes(prev)
+                ? response.loginStatus === LOGIN_STATUSES.success
+                    ? LOGIN_STATUSES.success2fa
+                    : LOGIN_STATUSES.secondAttempt2fa
+                : response.loginStatus
+        )
+
+        if (response.loginStatus === LOGIN_STATUSES.success) {
+            const redirectString = getRedirectString({ response, baseUrl })
+            redirectTo(redirectString)
+        }
+    }
+
+    const handleUnsuccessfulLogin = (error) => {
+        console.error(error)
+        setLoginStatus(null)
+        setError(error)
+    }
+
     const [login, { loading, fetching }] = useDataMutation(loginMutation, {
         onComplete: (response) => {
-            setError(null)
-            // we need to distinguish between incorrect 2fa on second attempt
-            setLoginStatus((prev) =>
-                invalidTWOFA.includes(prev)
-                    ? response.loginStatus === LOGIN_STATUSES.success
-                        ? LOGIN_STATUSES.success2fa
-                        : LOGIN_STATUSES.secondAttempt2fa
-                    : response.loginStatus
-            )
-
-            if (response.loginStatus === LOGIN_STATUSES.success) {
-                const redirectString = getRedirectString({ response, baseUrl })
-                window.location.href = redirectString
-            }
+            handleSuccessfulLogin(response)
         },
-        onError: (e) => {
-            console.error(e)
-            setLoginStatus(null)
-            setError(e)
+        onError: (error) => {
+            handleUnsuccessfulLogin(error)
         },
     })
 

--- a/src/pages/__tests__/login.test.js
+++ b/src/pages/__tests__/login.test.js
@@ -1,0 +1,139 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { checkIsLoginFormValid } from '../../helpers/validators.js'
+import { useLogin } from '../../hooks/useLogin.js'
+import { LoginFormContainer } from '../login.js'
+
+jest.mock('../../helpers/validators.js', () => ({
+    getIsRequired: () => () => null,
+    checkIsLoginFormValid: jest.fn(),
+}))
+
+const mockLogin = jest.fn()
+
+jest.mock('../../hooks/useLogin.js', () => ({
+    useLogin: jest.fn(() => ({
+        login: mockLogin,
+        cancelTwoFA: () => {},
+        twoFAVerificationRequired: false,
+    })),
+}))
+
+jest.mock('../../components/index.js', () => ({
+    ...jest.requireActual('../../components/index.js'),
+    LoginLinks: () => <p>LOGIN LINKS</p>,
+    OIDCLoginOptions: () => <p>OIDC LOGIN OPTIONS</p>,
+}))
+
+describe('LoginForm', () => {
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('validates the form upon submission', () => {
+        render(<LoginFormContainer />)
+
+        fireEvent.click(
+            screen.getByRole('button', {
+                name: /log in/i,
+            })
+        )
+        expect(checkIsLoginFormValid).toHaveBeenCalled()
+    })
+
+    it('performs login on submission (if form valid) ', () => {
+        checkIsLoginFormValid.mockImplementation(() => true)
+        render(<LoginFormContainer />)
+
+        fireEvent.click(screen.getByRole('button'))
+        expect(mockLogin).toHaveBeenCalled()
+    })
+
+    it('does not perform login on submission (if form is not valid) ', () => {
+        checkIsLoginFormValid.mockImplementation(() => false)
+        render(<LoginFormContainer />)
+
+        fireEvent.click(screen.getByRole('button'))
+        expect(mockLogin).not.toHaveBeenCalled()
+    })
+
+    it('cancels twofa when cancel is clicked', () => {
+        const mockCancelTwoFA = jest.fn()
+        useLogin.mockImplementationOnce(() => ({
+            login: () => {},
+            twoFAVerificationRequired: true,
+            cancelTwoFA: mockCancelTwoFA,
+        }))
+        render(<LoginFormContainer />)
+
+        fireEvent.click(
+            screen.getByRole('button', {
+                name: /cancel/i,
+            })
+        )
+        expect(mockCancelTwoFA).toHaveBeenCalled()
+    })
+
+    // ideally would check visibility of fields in these states, but not working in tests due to jsdom interpretation of css
+    it('has header of "log in" if twoFAVerificationRequired is false', () => {
+        render(<LoginFormContainer />)
+
+        expect(screen.getByRole('heading', { name: /log in/i })).not.toBe(null)
+    })
+
+    it('has header of "Two-factor authentication" if twoFAVerificationRequired is true', () => {
+        useLogin.mockImplementationOnce(() => ({
+            login: () => {},
+            twoFAVerificationRequired: true,
+            cancelTwoFA: () => {},
+        }))
+        render(<LoginFormContainer />)
+
+        expect(
+            screen.getByRole('heading', { name: /two-factor authentication/i })
+        ).not.toBe(null)
+    })
+
+    it('shows incorrect username error on 401 error ', () => {
+        useLogin.mockImplementationOnce(() => ({
+            login: () => {},
+            twoFAVerificationRequired: false,
+            cancelTwoFA: () => {},
+            error: { httpStatusCode: 401 },
+        }))
+        render(<LoginFormContainer />)
+
+        expect(screen.getByText('Incorrect username or password')).toBeVisible()
+    })
+
+    it('does not show inputs if login function is not defined ', () => {
+        useLogin.mockImplementationOnce(() => ({ login: null }))
+        render(<LoginFormContainer />)
+
+        expect(screen.queryAllByRole('textbox')).toHaveLength(0)
+    })
+
+    it('hides login links and oidc login options if two fa required ', () => {
+        useLogin.mockImplementationOnce(() => ({
+            login: () => {},
+            twoFAVerificationRequired: true,
+            cancelTwoFA: () => {},
+        }))
+        render(<LoginFormContainer />)
+
+        expect(screen.queryByText('LOGIN LINKS')).toBe(null)
+        expect(screen.queryByText('OIDC LOGIN OPTIONS')).toBe(null)
+    })
+
+    it('show login links and oidc login options if two fa not (yet) required ', () => {
+        useLogin.mockImplementationOnce(() => ({
+            login: () => {},
+            twoFAVerificationRequired: false,
+            cancelTwoFA: () => {},
+        }))
+        render(<LoginFormContainer />)
+
+        expect(screen.getByText('LOGIN LINKS')).toBeInTheDocument()
+        expect(screen.getByText('OIDC LOGIN OPTIONS')).toBeInTheDocument()
+    })
+})

--- a/src/pages/__tests__/login.test.js
+++ b/src/pages/__tests__/login.test.js
@@ -59,11 +59,11 @@ describe('LoginForm', () => {
 
     it('cancels twofa when cancel is clicked', () => {
         const mockCancelTwoFA = jest.fn()
-        useLogin.mockImplementationOnce(() => ({
+        useLogin.mockReturnValue({
             login: () => {},
             twoFAVerificationRequired: true,
             cancelTwoFA: mockCancelTwoFA,
-        }))
+        })
         render(<LoginFormContainer />)
 
         fireEvent.click(
@@ -76,17 +76,22 @@ describe('LoginForm', () => {
 
     // ideally would check visibility of fields in these states, but not working in tests due to jsdom interpretation of css
     it('has header of "log in" if twoFAVerificationRequired is false', () => {
+        useLogin.mockReturnValue({
+            login: () => {},
+            twoFAVerificationRequired: false,
+            cancelTwoFA: () => {},
+        })
         render(<LoginFormContainer />)
 
         expect(screen.getByRole('heading', { name: /log in/i })).not.toBe(null)
     })
 
     it('has header of "Two-factor authentication" if twoFAVerificationRequired is true', () => {
-        useLogin.mockImplementationOnce(() => ({
+        useLogin.mockReturnValue({
             login: () => {},
             twoFAVerificationRequired: true,
             cancelTwoFA: () => {},
-        }))
+        })
         render(<LoginFormContainer />)
 
         expect(
@@ -95,30 +100,30 @@ describe('LoginForm', () => {
     })
 
     it('shows incorrect username error on 401 error ', () => {
-        useLogin.mockImplementationOnce(() => ({
+        useLogin.mockReturnValue({
             login: () => {},
             twoFAVerificationRequired: false,
             cancelTwoFA: () => {},
             error: { httpStatusCode: 401 },
-        }))
+        })
         render(<LoginFormContainer />)
 
         expect(screen.getByText('Incorrect username or password')).toBeVisible()
     })
 
     it('does not show inputs if login function is not defined ', () => {
-        useLogin.mockImplementationOnce(() => ({ login: null }))
+        useLogin.mockReturnValue({ login: null })
         render(<LoginFormContainer />)
 
         expect(screen.queryAllByRole('textbox')).toHaveLength(0)
     })
 
     it('hides login links and oidc login options if two fa required ', () => {
-        useLogin.mockImplementationOnce(() => ({
+        useLogin.mockReturnValue({
             login: () => {},
             twoFAVerificationRequired: true,
             cancelTwoFA: () => {},
-        }))
+        })
         render(<LoginFormContainer />)
 
         expect(screen.queryByText('LOGIN LINKS')).toBe(null)
@@ -126,11 +131,11 @@ describe('LoginForm', () => {
     })
 
     it('show login links and oidc login options if two fa not (yet) required ', () => {
-        useLogin.mockImplementationOnce(() => ({
+        useLogin.mockReturnValue({
             login: () => {},
             twoFAVerificationRequired: false,
             cancelTwoFA: () => {},
-        }))
+        })
         render(<LoginFormContainer />)
 
         expect(screen.getByText('LOGIN LINKS')).toBeInTheDocument()

--- a/src/pages/__tests__/password-reset-request.test.js
+++ b/src/pages/__tests__/password-reset-request.test.js
@@ -1,0 +1,150 @@
+import { useDataMutation } from '@dhis2/app-runtime'
+import { screen, fireEvent } from '@testing-library/react'
+import React from 'react'
+import { useLoginConfig } from '../../providers/use-login-config.js'
+import { renderWithRouter } from '../../test-utils/render-with-router.js'
+import PasswordResetRequestPage from '../password-reset-request.js'
+
+jest.mock('../../components/not-allowed-notice.js', () => ({
+    NotAllowedNotice: () => <div>NOT ALLOWED</div>,
+}))
+
+jest.mock('../../components/back-to-login-button.js', () => ({
+    BackToLoginButton: () => <div>BACK_TO_LOGIN</div>,
+}))
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useSearchParams: jest.fn(() => [
+        {
+            get: (param) => {
+                if (param === 'username') {
+                    return 'lakris'
+                }
+                return null
+            },
+        },
+    ]),
+}))
+
+const mockMutate = jest.fn()
+
+jest.mock('@dhis2/app-runtime', () => ({
+    ...jest.requireActual('@dhis2/app-runtime'),
+    useDataMutation: jest.fn(() => [
+        mockMutate,
+        { loading: false, fetching: false, error: false, data: null },
+    ]),
+}))
+
+jest.mock('../../providers/use-login-config.js', () => ({
+    useLoginConfig: jest.fn(),
+}))
+
+describe('PasswordResetRequestPage', () => {
+    afterEach(() => {
+        jest.clearAllMocks()
+    })
+
+    it('shows back to login button if page is available', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+        })
+        renderWithRouter(<PasswordResetRequestPage />)
+
+        expect(screen.getByText('BACK_TO_LOGIN')).toBeInTheDocument()
+    })
+
+    it('has mutation that points to auth/forgotPassword', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+        })
+        renderWithRouter(<PasswordResetRequestPage />)
+
+        expect(useDataMutation).toHaveBeenCalledWith(
+            expect.objectContaining({ resource: 'auth/forgotPassword' })
+        )
+    })
+
+    it('calls mutation when reset password is clicked', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+        })
+        renderWithRouter(<PasswordResetRequestPage />)
+
+        fireEvent.click(
+            screen.getByRole('button', {
+                name: /send password reset/i,
+            })
+        )
+
+        expect(mockMutate).toHaveBeenCalled()
+    })
+
+    it('displays not allowed notice if allowAccountRecovery:false', async () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: false,
+            emailConfigured: true,
+        })
+        renderWithRouter(<PasswordResetRequestPage />)
+        expect(screen.getByText('NOT ALLOWED')).toBeInTheDocument()
+    })
+
+    it('displays not allowed notice if emailConfigured:false', async () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: false,
+        })
+        renderWithRouter(<PasswordResetRequestPage />)
+        expect(screen.getByText('NOT ALLOWED')).toBeInTheDocument()
+    })
+
+    it('displays not allowed notice if emailConfigured:false', async () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: false,
+        })
+        renderWithRouter(<PasswordResetRequestPage />)
+        expect(screen.getByText('NOT ALLOWED')).toBeInTheDocument()
+    })
+
+    it('populates url from username parameters if one is provide', () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+        })
+        renderWithRouter(<PasswordResetRequestPage />)
+        expect(screen.getByDisplayValue('lakris')).toHaveAttribute(
+            'id',
+            'emailOrUsername'
+        )
+    })
+
+    it('displays error message if error returned from mutation', async () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+        })
+        useDataMutation.mockReturnValue([
+            () => {},
+            { error: new Error('some random error') },
+        ])
+        renderWithRouter(<PasswordResetRequestPage />)
+        expect(screen.getByText(/password reset failed/i)).toBeInTheDocument()
+    })
+
+    it('displays message about email sent if mutation succeeeds', async () => {
+        useLoginConfig.mockReturnValue({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+        })
+        useDataMutation.mockReturnValue([() => {}, { data: { success: true } }])
+        renderWithRouter(<PasswordResetRequestPage />)
+        expect(
+            screen.getByText(/you will soon receive an email/i)
+        ).toBeInTheDocument()
+    })
+})

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -90,7 +90,6 @@ const InnerLoginForm = ({
             >
                 <ReactFinalForm.Field
                     name="twoFA"
-                    data-test="input-twoFA"
                     label={i18n.t('Authentication code', { lng: uiLocale })}
                     component={InputFieldFF}
                     className={styles.inputField}

--- a/src/pages/password-reset-request.js
+++ b/src/pages/password-reset-request.js
@@ -71,7 +71,7 @@ const InnerPasswordResetRequestForm = ({
 InnerPasswordResetRequestForm.propTypes = {
     formSubmitted: PropTypes.bool,
     handleSubmit: PropTypes.func,
-    isRequired: PropTypes.bool,
+    isRequired: PropTypes.func,
     loading: PropTypes.bool,
     uiLocale: PropTypes.string,
 }

--- a/src/pages/password-reset-request.js
+++ b/src/pages/password-reset-request.js
@@ -71,7 +71,7 @@ const InnerPasswordResetRequestForm = ({
 InnerPasswordResetRequestForm.propTypes = {
     formSubmitted: PropTypes.bool,
     handleSubmit: PropTypes.func,
-    isRequired: PropTypes.func,
+    isRequired: PropTypes.bool,
     loading: PropTypes.bool,
     uiLocale: PropTypes.string,
 }

--- a/src/providers/__tests__/use-login-config.test.js
+++ b/src/providers/__tests__/use-login-config.test.js
@@ -1,0 +1,181 @@
+import { renderHook } from '@testing-library/react-hooks'
+import React from 'react'
+import { LoginConfigProvider } from '../login-config-provider.js'
+import { useLoginConfig } from '../use-login-config.js'
+
+const mockEngineQuery = jest.fn()
+
+const TEST_LOCALES = [
+    { locale: 'ar', displayName: 'Arabic', name: 'العربية' },
+    { locale: 'en', displayName: 'English', name: 'English' },
+    { locale: 'nb', displayName: 'Norwegian', name: 'norsk' },
+    { locale: 'fr', displayName: 'French', name: 'français' },
+]
+
+const TEST_TRANSLATIONS = {
+    en: {
+        applicationDescription: "Don't forget a towel",
+        applicationLeftSideFooter:
+            'At the end of the universe, on the left side',
+        applicationRightSideFooter:
+            'At the end of the universe, on the right side',
+        applicationNotification: 'The meaning of the universe is 42',
+        applicationTitle: "The Hithchiker's guide to DHIS2",
+    },
+    nb: {
+        applicationDescription: 'Glem ikke håndkle',
+        applicationLeftSideFooter: 'Der universet slutter, på venstre siden',
+        applicationRightSideFooter: 'Der universet slutter, på høyre siden',
+        applicationTitle: 'Haikerens guide til DHIS2',
+    },
+    fr: {
+        applicationNotification:
+            "La réponse à la grande question de l'univers et tout ça: 42",
+        applicationTitle: 'Le guide du voyageur DHIS2',
+    },
+    es: {
+        applicationTitle: 'Guía del autoestopista DHIS2',
+    },
+}
+
+jest.mock('@dhis2/app-runtime', () => ({
+    ...jest.requireActual('@dhis2/app-runtime'),
+    useDataEngine: () => ({ query: mockEngineQuery }),
+    useDataQuery: jest.fn((query, variables) => {
+        if (query?.loginConfig?.resource === 'loginConfig') {
+            return {
+                data: {
+                    loginConfig: {
+                        ...TEST_TRANSLATIONS[
+                            variables?.variables?.locale ?? 'en'
+                        ],
+                    },
+                },
+                loading: false,
+                error: null,
+            }
+        }
+        return {
+            data: { localesUI: { ...TEST_LOCALES } },
+            loading: false,
+            error: null,
+        }
+    }),
+}))
+
+describe('useAppContext', () => {
+    const wrapper = ({ children }) => (
+        <LoginConfigProvider>{children}</LoginConfigProvider>
+    )
+
+    afterEach(() => {
+        jest.clearAllMocks()
+        localStorage.clear()
+    })
+
+    it('has refreshOnTranslation function', () => {
+        const { result } = renderHook(() => useLoginConfig(), { wrapper })
+
+        expect(result.current).toHaveProperty('refreshOnTranslation')
+        expect(typeof result.current.refreshOnTranslation).toBe('function')
+    })
+
+    // note: system language is English by default (if not provided by api)
+    it('updates uiLocale on translation, keeps systemLocale unchanged ', async () => {
+        const { result, waitForNextUpdate } = renderHook(
+            () => useLoginConfig(),
+            { wrapper }
+        )
+        expect(result.current.systemLocale).toBe('en')
+        expect(result.current.uiLocale).toBe('en')
+        result.current.refreshOnTranslation({ locale: 'nb' })
+        await waitForNextUpdate()
+        expect(result.current.systemLocale).toBe('en')
+        expect(result.current.uiLocale).toBe('nb')
+    })
+
+    it('updates translatable values on translation', async () => {
+        const { result, waitForNextUpdate } = renderHook(
+            () => useLoginConfig(),
+            { wrapper }
+        )
+        mockEngineQuery.mockResolvedValue({
+            loginConfig: { ...TEST_TRANSLATIONS.nb },
+        })
+
+        result.current.refreshOnTranslation({ locale: 'nb' })
+        await waitForNextUpdate()
+        expect(result.current.applicationDescription).toBe('Glem ikke håndkle')
+        // if value is not translated, keeps previous value
+        expect(result.current.applicationNotification).toBe(
+            'The meaning of the universe is 42'
+        )
+    })
+
+    // note: this test confirms the INCORRECT behaviour in the app
+    // app should fall back to default system locale values, but will persist last fetched translations
+    // this does not cause problems because the api returns the default values
+    it('falls back to default system language values on subsequent translations', async () => {
+        const { result, waitForNextUpdate } = renderHook(
+            () => useLoginConfig(),
+            { wrapper }
+        )
+        mockEngineQuery.mockResolvedValueOnce({
+            loginConfig: { ...TEST_TRANSLATIONS.nb },
+        })
+
+        result.current.refreshOnTranslation({ locale: 'nb' })
+        await waitForNextUpdate()
+        expect(result.current.applicationLeftSideFooter).toBe(
+            'Der universet slutter, på venstre siden'
+        )
+
+        mockEngineQuery.mockResolvedValueOnce({
+            loginConfig: { ...TEST_TRANSLATIONS.fr },
+        })
+        result.current.refreshOnTranslation({ locale: 'fr' })
+        await waitForNextUpdate()
+        expect(result.current.applicationLeftSideFooter).toBe(
+            'Der universet slutter, på venstre siden'
+        )
+        expect(result.current.applicationTitle).toBe(
+            'Le guide du voyageur DHIS2'
+        )
+    })
+
+    it('persists language in local storage as ui language on refreshOnTranslation', async () => {
+        const spySetItem = jest.spyOn(Storage.prototype, 'setItem')
+        const { result, waitForNextUpdate } = renderHook(
+            () => useLoginConfig(),
+            { wrapper }
+        )
+        result.current.refreshOnTranslation({ locale: 'zh' })
+        await waitForNextUpdate()
+        expect(spySetItem).toHaveBeenCalled()
+        expect(spySetItem).toHaveBeenCalledWith('dhis2.locale.ui', 'zh')
+    })
+
+    it('updates document direction on refreshOnTranslation (if applicable)', async () => {
+        const { result, waitForNextUpdate } = renderHook(
+            () => useLoginConfig(),
+            { wrapper }
+        )
+        // uiLocale is 'en' by default, hence dir is 'ltr'
+        expect(document.dir).toBe('ltr')
+        result.current.refreshOnTranslation({ locale: 'ar' })
+        await waitForNextUpdate()
+        expect(document.dir).toBe('rtl')
+        result.current.refreshOnTranslation({ locale: 'fr' })
+        await waitForNextUpdate()
+        expect(document.dir).toBe('ltr')
+    })
+
+    it('uses language persisted in local storage as ui language when first loaded', () => {
+        jest.spyOn(Storage.prototype, 'getItem').mockReturnValue('es')
+        const { result } = renderHook(() => useLoginConfig(), { wrapper })
+        expect(result.current.uiLocale).toBe('es')
+        expect(result.current.applicationTitle).toBe(
+            'Guía del autoestopista DHIS2'
+        )
+    })
+})

--- a/src/providers/login-config-provider.js
+++ b/src/providers/login-config-provider.js
@@ -46,7 +46,7 @@ const LoginConfigProvider = ({ children }) => {
         loading: loginConfigLoading,
         error: loginConfigError,
     } = useDataQuery(loginConfigQuery, {
-        variables: { locale: localStorage[localStorageLocaleKey] },
+        variables: { locale: localStorage.getItem(localStorageLocaleKey) },
     })
     const {
         data: localesData,
@@ -60,7 +60,7 @@ const LoginConfigProvider = ({ children }) => {
     useEffect(() => {
         // if there is a stored language, set it as i18next language
         const userLanguage =
-            localStorage[localStorageLocaleKey] ||
+            localStorage.getItem(localStorageLocaleKey) ||
             loginConfigData?.loginConfig?.uiLocale ||
             'en'
         setTranslatedValues({ uiLocale: userLanguage })
@@ -84,6 +84,8 @@ const LoginConfigProvider = ({ children }) => {
         }
         i18n.changeLanguage(locale)
         document.documentElement.setAttribute('dir', i18n.dir())
+        // the logic here is wrong as it falls back to previous translations (rather than defaults)
+        // however, the api response will fall back to default system language (so this doesn't cause issues)
         const updatedTranslations = translatableValues.reduce(
             (translations, currentTranslationKey) => {
                 if (updatedValues?.loginConfig?.[currentTranslationKey]) {

--- a/src/test-utils/index.js
+++ b/src/test-utils/index.js
@@ -1,0 +1,1 @@
+export { renderWithRouter } from './render-with-router.js'

--- a/src/test-utils/render-with-router.js
+++ b/src/test-utils/render-with-router.js
@@ -1,0 +1,6 @@
+import { render } from '@testing-library/react'
+import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
+
+export const renderWithRouter = (component) =>
+    render(<MemoryRouter>{component}</MemoryRouter>)

--- a/src/test-utils/setup-tests.js
+++ b/src/test-utils/setup-tests.js
@@ -1,0 +1,7 @@
+import '@testing-library/jest-dom'
+import { configure } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import * as matchers from 'jest-extended'
+expect.extend(matchers)
+
+configure({ adapter: new Adapter() })

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,11 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
+"@adobe/css-tools@^4.3.2":
+  version "4.3.3"
+  resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.3.tgz#90749bde8b89cd41764224f5aac29cd4138f75ff"
+  integrity sha512-rE0Pygv0sEZ4vBWHlAgJLGDU7Pm8xoO6p3wsEceb7GYAjScrOHpEo8KK/eVkAcnSM+slAEtXjA2JpdjLp4fJQQ==
+
 "@alloc/quick-lru@^5.2.0":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@alloc/quick-lru/-/quick-lru-5.2.0.tgz#7bf68b20c0a350f936915fcae06f58e32007ce30"
@@ -1164,6 +1169,13 @@
   version "7.24.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.0.tgz#584c450063ffda59697021430cb47101b085951e"
   integrity sha512-Chk32uHMg6TnQdvw2e9IlqPpFX/6NLuK0Ys2PqLb7/gL5uFn9mXvK715FGLlOLQrcO4qIkNHkvPGktzzXexsFw==
+  dependencies:
+    regenerator-runtime "^0.14.0"
+
+"@babel/runtime@^7.9.2":
+  version "7.24.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.24.5.tgz#230946857c053a36ccc66e1dd03b17dd0c4ed02c"
+  integrity sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==
   dependencies:
     regenerator-runtime "^0.14.0"
 
@@ -2578,6 +2590,13 @@
   dependencies:
     "@sinclair/typebox" "^0.24.1"
 
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.6.3.tgz#430b5ce8a4e0044a7e3819663305a7b3091c8e03"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
 "@jest/source-map@^27.5.1":
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-27.5.1.tgz#6608391e465add4205eae073b55e7f279e04e8cf"
@@ -2856,6 +2875,11 @@
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
   integrity sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==
 
+"@sinclair/typebox@^0.27.8":
+  version "0.27.8"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.27.8.tgz#6667fac16c436b5434a387a34dedb013198f6e6e"
+  integrity sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -3008,6 +3032,28 @@
     dom-accessibility-api "^0.5.9"
     lz-string "^1.5.0"
     pretty-format "^27.0.2"
+
+"@testing-library/jest-dom@^6.4.5":
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/jest-dom/-/jest-dom-6.4.5.tgz#badb40296477149136dabef32b572ddd3b56adf1"
+  integrity sha512-AguB9yvTXmCnySBP1lWjfNNUwpbElsaQ567lt2VdGqAdHtpieLgjmcVyv1q7PMIvLbgpDdkWV5Ydv3FEejyp2A==
+  dependencies:
+    "@adobe/css-tools" "^4.3.2"
+    "@babel/runtime" "^7.9.2"
+    aria-query "^5.0.0"
+    chalk "^3.0.0"
+    css.escape "^1.5.1"
+    dom-accessibility-api "^0.6.3"
+    lodash "^4.17.21"
+    redent "^3.0.0"
+
+"@testing-library/react-hooks@^8.0.1":
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-8.0.1.tgz#0924bbd5b55e0c0c0502d1754657ada66947ca12"
+  integrity sha512-Aqhl2IVmLt8IovEVarNDFuJDVWVvhnr9/GCU6UUnrYXwgDFF9h2L2o2P9KBni1AST5sT6riAyoukFLyjQUgD/g==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    react-error-boundary "^3.1.0"
 
 "@testing-library/react@^12.1.2":
   version "12.1.5"
@@ -3756,6 +3802,21 @@ agent-base@6:
   dependencies:
     debug "4"
 
+airbnb-prop-types@^2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/airbnb-prop-types/-/airbnb-prop-types-2.16.0.tgz#b96274cefa1abb14f623f804173ee97c13971dc2"
+  integrity sha512-7WHOFolP/6cS96PhKNrslCLMYAI8yB1Pp6u6XmxozQOiZbsI5ycglZr5cHhBFfuRcQQjzCMith5ZPZdYiJCxUg==
+  dependencies:
+    array.prototype.find "^2.1.1"
+    function.prototype.name "^1.1.2"
+    is-regex "^1.1.0"
+    object-is "^1.1.2"
+    object.assign "^4.1.0"
+    object.entries "^1.1.2"
+    prop-types "^15.7.2"
+    prop-types-exact "^1.2.0"
+    react-is "^16.13.1"
+
 ajv-formats@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
@@ -3936,7 +3997,7 @@ aria-query@5.1.3:
   dependencies:
     deep-equal "^2.0.5"
 
-aria-query@^5.3.0:
+aria-query@^5.0.0, aria-query@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
   integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
@@ -3977,6 +4038,18 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+array.prototype.filter@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/array.prototype.filter/-/array.prototype.filter-1.0.4.tgz#bef83fde8a36a14d3de988c43563e0f5249962bf"
+  integrity sha512-r+mCJ7zXgXElgR4IRC+fkvNCeoaavWBs6EdCso5Tbcf+iEMKzBU/His60lt34WEZ9vlb8wDkZvQGcVI5GwkfoQ==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.2"
+    es-array-method-boxes-properly "^1.0.0"
+    es-object-atoms "^1.0.0"
+    is-string "^1.0.7"
+
 array.prototype.filter@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array.prototype.filter/-/array.prototype.filter-1.0.3.tgz#423771edeb417ff5914111fff4277ea0624c0d0e"
@@ -3987,6 +4060,17 @@ array.prototype.filter@^1.0.3:
     es-abstract "^1.22.1"
     es-array-method-boxes-properly "^1.0.0"
     is-string "^1.0.7"
+
+array.prototype.find@^2.1.1:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.find/-/array.prototype.find-2.2.3.tgz#675a233dbcd9b65ecf1fb3f915741aebc45461e6"
+  integrity sha512-fO/ORdOELvjbbeIfZfzrXFMhYHGofRGqd+am9zm3tZ4GlJINj/pA2eITyfd65Vg6+ZbHd/Cys7stpoRSWtQFdA==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-abstract "^1.23.2"
+    es-object-atoms "^1.0.0"
+    es-shim-unscopables "^1.0.2"
 
 array.prototype.findlast@^1.2.4:
   version "1.2.4"
@@ -4010,7 +4094,7 @@ array.prototype.findlastindex@^1.2.3:
     es-errors "^1.3.0"
     es-shim-unscopables "^1.0.2"
 
-array.prototype.flat@^1.3.1, array.prototype.flat@^1.3.2:
+array.prototype.flat@^1.2.3, array.prototype.flat@^1.3.1, array.prototype.flat@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz#1476217df8cff17d72ee8f3ba06738db5b387d18"
   integrity sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==
@@ -4696,6 +4780,31 @@ check-types@^11.2.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-11.2.3.tgz#1ffdf68faae4e941fce252840b1787b8edc93b71"
   integrity sha512-+67P1GkJRaxQD6PKK0Et9DhwQB+vGg3PM5+aavopCpZT1lj9jeqfvpgTLAWErNj8qApkkmXlu/Ug74kmhagkXg==
 
+cheerio-select@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/cheerio-select/-/cheerio-select-2.1.0.tgz#4d8673286b8126ca2a8e42740d5e3c4884ae21b4"
+  integrity sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==
+  dependencies:
+    boolbase "^1.0.0"
+    css-select "^5.1.0"
+    css-what "^6.1.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+
+cheerio@^1.0.0-rc.3:
+  version "1.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.12.tgz#788bf7466506b1c6bf5fae51d24a2c4d62e47683"
+  integrity sha512-VqR8m68vM46BNnuZ5NtnGBKIE/DfN0cRIzg9n40EIq9NOv90ayxLBXA8fXC5gquFRGJSTRqBq25Jt2ECLR431Q==
+  dependencies:
+    cheerio-select "^2.1.0"
+    dom-serializer "^2.0.0"
+    domhandler "^5.0.3"
+    domutils "^3.0.1"
+    htmlparser2 "^8.0.1"
+    parse5 "^7.0.0"
+    parse5-htmlparser2-tree-adapter "^7.0.0"
+
 chokidar@^3.3.0, chokidar@^3.4.2, chokidar@^3.5.3:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.6.0.tgz#197c6cc669ef2a8dc5e7b4d97ee4e092c3eb0d5b"
@@ -5258,6 +5367,17 @@ css-select@^4.1.3:
     domutils "^2.8.0"
     nth-check "^2.0.1"
 
+css-select@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-5.1.0.tgz#b8ebd6554c3637ccc76688804ad3f6a6fdaea8a6"
+  integrity sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==
+  dependencies:
+    boolbase "^1.0.0"
+    css-what "^6.1.0"
+    domhandler "^5.0.2"
+    domutils "^3.0.1"
+    nth-check "^2.0.1"
+
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
   resolved "https://registry.yarnpkg.com/css-tree/-/css-tree-1.0.0-alpha.37.tgz#98bebd62c4c1d9f960ec340cf9f7522e30709a22"
@@ -5279,10 +5399,15 @@ css-what@^3.2.1:
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-3.4.2.tgz#ea7026fcb01777edbde52124e21f327e7ae950e4"
   integrity sha512-ACUm3L0/jiZTqfzRM3Hi9Q8eZqd6IK37mMWPLz9PJxkLWllYeRf+EHUSHYEtFop2Eqytaq1FizFVh7XfBnXCDQ==
 
-css-what@^6.0.1:
+css-what@^6.0.1, css-what@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/css-what/-/css-what-6.1.0.tgz#fb5effcf76f1ddea2c81bdfaa4de44e79bac70f4"
   integrity sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==
+
+css.escape@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
+  integrity sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==
 
 cssdb@^7.1.0:
   version "7.11.2"
@@ -5611,12 +5736,22 @@ diff-sequences@^27.5.1:
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
   integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
+diff-sequences@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"
   integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
   dependencies:
     path-type "^4.0.0"
+
+discontinuous-range@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/discontinuous-range/-/discontinuous-range-1.0.0.tgz#e38331f0844bba49b9a9cb71c771585aab1bc65a"
+  integrity sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==
 
 dlv@^1.1.3:
   version "1.1.3"
@@ -5648,6 +5783,11 @@ dom-accessibility-api@^0.5.9:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
   integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
+
+dom-accessibility-api@^0.6.3:
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz#993e925cc1d73f2c662e7d75dd5a5445259a8fd8"
+  integrity sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==
 
 dom-converter@^0.2.0:
   version "0.2.0"
@@ -5923,6 +6063,70 @@ entities@^4.2.0, entities@^4.4.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+enzyme-adapter-react-16@^1.15.8:
+  version "1.15.8"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.8.tgz#1aecb5daadaae33d32c5b8b78566d7cf45dc49d8"
+  integrity sha512-uYGC31eGZBp5nGsr4nKhZKvxGQjyHGjS06BJsUlWgE29/hvnpgCsT1BJvnnyny7N3GIIVyxZ4O9GChr6hy2WQA==
+  dependencies:
+    enzyme-adapter-utils "^1.14.2"
+    enzyme-shallow-equal "^1.0.7"
+    hasown "^2.0.0"
+    object.assign "^4.1.5"
+    object.values "^1.1.7"
+    prop-types "^15.8.1"
+    react-is "^16.13.1"
+    react-test-renderer "^16.0.0-0"
+    semver "^5.7.2"
+
+enzyme-adapter-utils@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/enzyme-adapter-utils/-/enzyme-adapter-utils-1.14.2.tgz#1d012e6261accbe7d406db098bb4d8dfdce8c003"
+  integrity sha512-1ZC++RlsYRaiOWE5NRaF5OgsMt7F5rn/VuaJIgc7eW/fmgg8eS1/Ut7EugSPPi7VMdWMLcymRnMF+mJUJ4B8KA==
+  dependencies:
+    airbnb-prop-types "^2.16.0"
+    function.prototype.name "^1.1.6"
+    hasown "^2.0.0"
+    object.assign "^4.1.5"
+    object.fromentries "^2.0.7"
+    prop-types "^15.8.1"
+    semver "^6.3.1"
+
+enzyme-shallow-equal@^1.0.1, enzyme-shallow-equal@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.7.tgz#4e3aa678022387a68e6c47aff200587851885b5e"
+  integrity sha512-/um0GFqUXnpM9SvKtje+9Tjoz3f1fpBC3eXRFrNs8kpYn69JljciYP7KZTqM/YQbUY9KUjvKB4jo/q+L6WGGvg==
+  dependencies:
+    hasown "^2.0.0"
+    object-is "^1.1.5"
+
+enzyme@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.11.0.tgz#71d680c580fe9349f6f5ac6c775bc3e6b7a79c28"
+  integrity sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==
+  dependencies:
+    array.prototype.flat "^1.2.3"
+    cheerio "^1.0.0-rc.3"
+    enzyme-shallow-equal "^1.0.1"
+    function.prototype.name "^1.1.2"
+    has "^1.0.3"
+    html-element-map "^1.2.0"
+    is-boolean-object "^1.0.1"
+    is-callable "^1.1.5"
+    is-number-object "^1.0.4"
+    is-regex "^1.0.5"
+    is-string "^1.0.5"
+    is-subset "^0.1.1"
+    lodash.escape "^4.0.1"
+    lodash.isequal "^4.5.0"
+    object-inspect "^1.7.0"
+    object-is "^1.0.2"
+    object.assign "^4.1.0"
+    object.entries "^1.1.1"
+    object.values "^1.1.1"
+    raf "^3.4.1"
+    rst-selector-parser "^2.2.3"
+    string.prototype.trim "^1.2.1"
 
 eol@^0.9.1:
   version "0.9.1"
@@ -6993,7 +7197,7 @@ function-bind@^1.1.2:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-function.prototype.name@^1.1.5, function.prototype.name@^1.1.6:
+function.prototype.name@^1.1.2, function.prototype.name@^1.1.5, function.prototype.name@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/function.prototype.name/-/function.prototype.name-1.1.6.tgz#cdf315b7d90ee77a4c6ee216c3c3362da07533fd"
   integrity sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==
@@ -7384,6 +7588,11 @@ has-yarn@^2.1.0:
   resolved "https://registry.yarnpkg.com/has-yarn/-/has-yarn-2.1.0.tgz#137e11354a7b5bf11aa5cb649cf0c6f3ff2b2e77"
   integrity sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==
 
+has@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.4.tgz#2eb2860e000011dae4f1406a86fe80e530fb2ec6"
+  integrity sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==
+
 hasown@^2.0.0, hasown@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.1.tgz#26f48f039de2c0f8d3356c223fb8d50253519faa"
@@ -7445,6 +7654,14 @@ html-dom-parser@3.1.7:
     domhandler "5.0.3"
     htmlparser2 "8.0.2"
 
+html-element-map@^1.2.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/html-element-map/-/html-element-map-1.3.1.tgz#44b2cbcfa7be7aa4ff59779e47e51012e1c73c08"
+  integrity sha512-6XMlxrAFX4UEEGxctfFnmrFaaZFNf9i5fNuV5wZ3WWQ4FVaNP1aX1LkX9j2mfEx1NpjeE/rL3nmgEn23GdFmrg==
+  dependencies:
+    array.prototype.filter "^1.0.0"
+    call-bind "^1.0.2"
+
 html-encoding-sniffer@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz#42a6dc4fd33f00281176e8b23759ca4e4fa185f3"
@@ -7496,7 +7713,7 @@ html-webpack-plugin@^5.5.0:
     pretty-error "^4.0.0"
     tapable "^2.0.0"
 
-htmlparser2@8.0.2:
+htmlparser2@8.0.2, htmlparser2@^8.0.1:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
   integrity sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==
@@ -7861,7 +8078,7 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-boolean-object@^1.1.0:
+is-boolean-object@^1.0.1, is-boolean-object@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.2.tgz#5c6dc200246dd9321ae4b885a114bb1f75f63719"
   integrity sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==
@@ -7874,7 +8091,7 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.7:
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.1.5, is-callable@^1.2.7:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.7.tgz#3bc2a85ea742d9e36205dcacdd72ca1fdc51b055"
   integrity sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==
@@ -8054,7 +8271,7 @@ is-potential-custom-element-name@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
   integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
-is-regex@^1.1.4:
+is-regex@^1.0.5, is-regex@^1.1.0, is-regex@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.4.tgz#eef5663cd59fa4c0ae339505323df6854bb15958"
   integrity sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==
@@ -8112,6 +8329,11 @@ is-string@^1.0.5, is-string@^1.0.7:
   integrity sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==
   dependencies:
     has-tostringtag "^1.0.0"
+
+is-subset@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/is-subset/-/is-subset-0.1.1.tgz#8a59117d932de1de00f245fcdd39ce43f1e939a6"
+  integrity sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==
 
 is-symbol@^1.0.2, is-symbol@^1.0.3:
   version "1.0.4"
@@ -8382,6 +8604,16 @@ jest-diff@^27.5.1:
     jest-get-type "^27.5.1"
     pretty-format "^27.5.1"
 
+jest-diff@^29.0.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-29.7.0.tgz#017934a66ebb7ecf6f205e84699be10afd70458a"
+  integrity sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^29.6.3"
+    jest-get-type "^29.6.3"
+    pretty-format "^29.7.0"
+
 jest-docblock@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-27.5.1.tgz#14092f364a42c6108d42c33c8cf30e058e25f6c0"
@@ -8425,10 +8657,23 @@ jest-environment-node@^27.5.1:
     jest-mock "^27.5.1"
     jest-util "^27.5.1"
 
+jest-extended@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/jest-extended/-/jest-extended-4.0.2.tgz#d23b52e687cedf66694e6b2d77f65e211e99e021"
+  integrity sha512-FH7aaPgtGYHc9mRjriS0ZEHYM5/W69tLrFTIdzm+yJgeoCmmrSB/luSfMSqWP9O29QWHPEmJ4qmU6EwsZideog==
+  dependencies:
+    jest-diff "^29.0.0"
+    jest-get-type "^29.0.0"
+
 jest-get-type@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
   integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
+
+jest-get-type@^29.0.0, jest-get-type@^29.6.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-29.6.3.tgz#36f499fdcea197c1045a127319c0481723908fd1"
+  integrity sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==
 
 jest-haste-map@^27.5.1:
   version "27.5.1"
@@ -9133,15 +9378,30 @@ lodash.difference@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
   integrity sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==
 
+lodash.escape@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.escape/-/lodash.escape-4.0.1.tgz#c9044690c21e04294beaa517712fded1fa88de98"
+  integrity sha512-nXEOnb/jK9g0DYMr1/Xvq6l5xMD7GDG55+GSYIYmS0G4tBk/hURD4JR9WCavs04t33WmJx9kCyp9vJ+mr4BOUw==
+
 lodash.flatten@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
   integrity sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==
 
+lodash.flattendeep@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
+  integrity sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==
+
 lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
+
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
 
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
@@ -9483,6 +9743,11 @@ moment@^2.24.0, moment@^2.29.1:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
   integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
+moo@^0.5.0:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.2.tgz#f9fe82473bc7c184b0d32e2215d3f6e67278733c"
+  integrity sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -9541,6 +9806,16 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
+
+nearley@^2.7.10:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/nearley/-/nearley-2.20.1.tgz#246cd33eff0d012faf197ff6774d7ac78acdd474"
+  integrity sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==
+  dependencies:
+    commander "^2.19.0"
+    moo "^0.5.0"
+    railroad-diagrams "^1.0.0"
+    randexp "0.4.6"
 
 negotiator@0.6.3:
   version "0.6.3"
@@ -9692,12 +9967,12 @@ object-hash@^3.0.0:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-3.0.0.tgz#73f97f753e7baffc0e2cc9d6e079079744ac82e9"
   integrity sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==
 
-object-inspect@^1.13.1:
+object-inspect@^1.13.1, object-inspect@^1.7.0:
   version "1.13.1"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.13.1.tgz#b96c6109324ccfef6b12216a956ca4dc2ff94bc2"
   integrity sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==
 
-object-is@^1.1.5:
+object-is@^1.0.2, object-is@^1.1.2, object-is@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/object-is/-/object-is-1.1.6.tgz#1a6a53aed2dd8f7e6775ff870bea58545956ab07"
   integrity sha512-F8cZ+KfGlSGi09lJT7/Nd6KJZ9ygtvYC0/UYYLI9nmQKLMnydpB9yvbv9K1uSkEu7FU9vYPmVwLg328tX+ot3Q==
@@ -9710,7 +9985,7 @@ object-keys@^1.1.1:
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
-object.assign@^4.0.4, object.assign@^4.1.4, object.assign@^4.1.5:
+object.assign@^4.0.4, object.assign@^4.1.0, object.assign@^4.1.4, object.assign@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.5.tgz#3a833f9ab7fdb80fc9e8d2300c803d216d8fdbb0"
   integrity sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==
@@ -9719,6 +9994,15 @@ object.assign@^4.0.4, object.assign@^4.1.4, object.assign@^4.1.5:
     define-properties "^1.2.1"
     has-symbols "^1.0.3"
     object-keys "^1.1.1"
+
+object.entries@^1.1.1, object.entries@^1.1.2:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/object.entries/-/object.entries-1.1.8.tgz#bffe6f282e01f4d17807204a24f8edd823599c41"
+  integrity sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==
+  dependencies:
+    call-bind "^1.0.7"
+    define-properties "^1.2.1"
+    es-object-atoms "^1.0.0"
 
 object.entries@^1.1.7:
   version "1.1.7"
@@ -9770,7 +10054,7 @@ object.hasown@^1.1.3:
     define-properties "^1.2.0"
     es-abstract "^1.22.1"
 
-object.values@^1.1.0:
+object.values@^1.1.0, object.values@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/object.values/-/object.values-1.2.0.tgz#65405a9d92cee68ac2d303002e0b8470a4d9ab1b"
   integrity sha512-yBYjY9QX2hnRmZHAjG/f13MzmBzxzYgQhFrke06TTyKY5zSTEqkOeukBzIdVA3j3ulu8Qa3MbVFShV7T2RmGtQ==
@@ -9982,6 +10266,14 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
+parse5-htmlparser2-tree-adapter@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz#23c2cc233bcf09bb7beba8b8a69d46b08c62c2f1"
+  integrity sha512-B77tOZrqqfUfnVcOrUvfdLbz4pu4RopLD/4vmu3HUPswwTA8OH0EMW9BlWR2B0RCoiZRAHEUu7IxeP1Pd1UU+g==
+  dependencies:
+    domhandler "^5.0.2"
+    parse5 "^7.0.0"
+
 parse5@6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
@@ -9991,6 +10283,13 @@ parse5@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-5.1.1.tgz#f68e4e5ba1852ac2cadc00f4555fff6c2abb6178"
   integrity sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+
+parse5@^7.0.0:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.2.tgz#0736bebbfd77793823240a23b7fc5e010b7f8e32"
+  integrity sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==
+  dependencies:
+    entities "^4.4.0"
 
 parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -10746,6 +11045,15 @@ pretty-format@^28.1.3:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
+pretty-format@^29.7.0:
+  version "29.7.0"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-29.7.0.tgz#ca42c758310f365bfa71a0bda0a807160b776812"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
+
 process-nextick-args@^2.0.0, process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -10770,6 +11078,15 @@ prompts@^2.0.1, prompts@^2.4.2:
   dependencies:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
+
+prop-types-exact@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
+  integrity sha512-K+Tk3Kd9V0odiXFP9fwDHUYRyvK3Nun3GVyPapSIs5OBkITAm15W0CPFD/YKTkMUAbc0b9CUwRQp2ybiBIq+eA==
+  dependencies:
+    has "^1.0.3"
+    object.assign "^4.1.0"
+    reflect.ownkeys "^0.2.0"
 
 prop-types@^15.5.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
@@ -10867,6 +11184,19 @@ raf@^3.4.1:
   dependencies:
     performance-now "^2.1.0"
 
+railroad-diagrams@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz#eb7e6267548ddedfb899c1b90e57374559cddb7e"
+  integrity sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==
+
+randexp@0.4.6:
+  version "0.4.6"
+  resolved "https://registry.yarnpkg.com/randexp/-/randexp-0.4.6.tgz#e986ad5e5e31dae13ddd6f7b3019aa7c87f60ca3"
+  integrity sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==
+  dependencies:
+    discontinuous-range "1.0.0"
+    ret "~0.1.10"
+
 randombytes@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/randombytes/-/randombytes-2.1.0.tgz#df6f84372f0270dc65cdf6291349ab7a473d4f2a"
@@ -10959,6 +11289,13 @@ react-dom@^16.8.6:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-error-boundary@^3.1.0:
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.4.tgz#255db92b23197108757a888b01e5b729919abde0"
+  integrity sha512-uM9uPzZJTF6wRQORmSrvOIgt4lJ9MC1sNgEOj2XGsDTRE4kmpWxg7ENK9EWNKJRMAOY9z0MuF4yIfl6gp4sotA==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
@@ -10984,7 +11321,7 @@ react-google-recaptcha@^3.1.0:
     prop-types "^15.5.0"
     react-async-script "^1.2.0"
 
-react-is@^16.13.1, react-is@^16.7.0:
+react-is@^16.13.1, react-is@^16.7.0, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -11096,6 +11433,16 @@ react-scripts@^5.0.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
+react-test-renderer@^16.0.0-0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.14.0.tgz#e98360087348e260c56d4fe2315e970480c228ae"
+  integrity sha512-L8yPjqPE5CZO6rKsKXRO/rVPiaCOy0tQQJbC+UjPNlobl5mad59lvPjwFsQHTvL03caVDIVr9x9/OSgDe6I5Eg==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.19.1"
+
 react@^16.8.6:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
@@ -11187,6 +11534,11 @@ reflect.getprototypeof@^1.0.4:
     get-intrinsic "^1.2.3"
     globalthis "^1.0.3"
     which-builtin-type "^1.1.3"
+
+reflect.ownkeys@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/reflect.ownkeys/-/reflect.ownkeys-0.2.0.tgz#749aceec7f3fdf8b63f927a04809e90c5c0b3460"
+  integrity sha512-qOLsBKHCpSOFKK1NUOCGC5VyeufB6lEsFe92AL2bhIJsacZS1qdoOZSbPk3MYKuT2cFlRDnulKXuuElIrMjGUg==
 
 regenerate-unicode-properties@^10.1.0:
   version "10.1.1"
@@ -11449,6 +11801,11 @@ restore-cursor@^3.1.0:
     onetime "^5.1.0"
     signal-exit "^3.0.2"
 
+ret@~0.1.10:
+  version "0.1.15"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
+  integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+
 retry@^0.13.1:
   version "0.13.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
@@ -11489,6 +11846,14 @@ rollup@^2.43.1:
   integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
   optionalDependencies:
     fsevents "~2.3.2"
+
+rst-selector-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz#81b230ea2fcc6066c89e3472de794285d9b03d91"
+  integrity sha512-nDG1rZeP6oFTLN6yNDV/uiAvs1+FS/KlrEwh7+y7dpuApDBy6bI2HTBcc0/V8lv9OTqfyD34eF7au2pm8aBbhA==
+  dependencies:
+    lodash.flattendeep "^4.4.0"
+    nearley "^2.7.10"
 
 run-async@^2.4.0:
   version "2.4.1"
@@ -11643,7 +12008,7 @@ semver-diff@^2.0.0:
   dependencies:
     semver "^5.0.3"
 
-"semver@2 || 3 || 4 || 5", semver@^5.0.3:
+"semver@2 || 3 || 4 || 5", semver@^5.0.3, semver@^5.7.2:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.2.tgz#48d55db737c3287cd4835e17fa13feace1c41ef8"
   integrity sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==
@@ -12144,16 +12509,7 @@ string.prototype.matchall@^4.0.6:
     set-function-name "^2.0.2"
     side-channel "^1.0.6"
 
-string.prototype.trim@^1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz#f9ac6f8af4bd55ddfa8895e6aea92a96395393bd"
-  integrity sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.2.0"
-    es-abstract "^1.22.1"
-
-string.prototype.trim@^1.2.9:
+string.prototype.trim@^1.2.1, string.prototype.trim@^1.2.9:
   version "1.2.9"
   resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.9.tgz#b6fa326d72d2c78b6df02f7759c73f8f6274faa4"
   integrity sha512-klHuCNxiMZ8MlsOihJhJEBJAiMVqU3Z2nEXWfWnIqjN0gEFS9J9+IxKozWWtQGcgoa1WUZzLjKPTr4ZHNFTFxw==
@@ -12162,6 +12518,15 @@ string.prototype.trim@^1.2.9:
     define-properties "^1.2.1"
     es-abstract "^1.23.0"
     es-object-atoms "^1.0.0"
+
+string.prototype.trim@^1.2.8:
+  version "1.2.8"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz#f9ac6f8af4bd55ddfa8895e6aea92a96395393bd"
+  integrity sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.2.0"
+    es-abstract "^1.22.1"
 
 string.prototype.trimend@^1.0.7:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3064,6 +3064,11 @@
     "@testing-library/dom" "^8.0.0"
     "@types/react-dom" "<18.0.0"
 
+"@testing-library/user-event@^14.5.2":
+  version "14.5.2"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.5.2.tgz#db7257d727c891905947bd1c1a99da20e03c2ebd"
+  integrity sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==
+
 "@tootallnate/once@1":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"


### PR DESCRIPTION
This PR adds unit tests for login app.

I've prioritized adding unit tests to cover the core functionality of the app (logging in, resetting password, HTML templates, language selection (this is relevant because the login app logic for language selection is different than in a logged-in app)).

### app entry
- I put the app.test.hs file here at the same level  as the app.js file as I didn't want to create a directory for one test file
- The tests here mostly check that the correct template will be loaded based on information from useLoginConfig and that the elements will be replaced with appropriate react elements (those tests are fairly repetitive, so maybe they would have been better structured as a scenario, but I didn't do that for a reason I don't remember now 🙃)

### hooks
- **useLogin** hook: this hook contains the logic to interpret the response from the backend into a state usable by the front end. The backend returns with "successful" responses when login is not complete (e.g. when username and password is provided, by 2fa is also required), hence the hook interprets the response and returns the proper state for login UI. Test of 
- **useLoginConfig** hook: most of the tests here are to confirm that language is being set/read correctly and that provider values get updated when useLoginConfig's refresh on translation function is called
- **useGetErrorIfNotAllowed**: this hook has general purpose logic to determine if page is allowed/not-allowed based on the required settings to view the page/system settings (stored in useLoginConfig)

### pages
- test of **login** page: main page for login. The tests here confirm that login function is being called, inputs are validated, appropriate inputs are passed into the login function, and additionally test that UI behaves appropriately--displays appropriate items based on state returned from useLogin, confirms some UI logic (e.g. fields are cleared when 2fa is cancelled).
- **password-reset-request**: page to request reset password. Testing mainly that request mutation gets fired on click with appropriate inputs, etc
- **password-update**: page to choose new password (after getting reset link). Testing mainly that mutation gets fired on click with appropriate inputs, etc

### components
- test of back button (with fake router) to check that it redirects to main route '/' (i.e. want to make sure it's possible for users to get back to the login page)
- customizable elements: here some tests that language selector should triggers language refresh (the function itself is tested in useLoginConfig tests), and some tests to confirm that they are displaying the values returned from useLoginConfig (this is also relevant to make sure that any translated values will actually be shown)
- login links: some tests to just make sure that correct options are available from login page

### miscellaneous
- under helpers: tests of HTML sanitization/parsing, login inputs validation, redirect parsing
