### PR TITLE
fix: error messages based on status code [DHIS2-17433]

### DIFF
--- a/src/pages/__tests__/login.test.js
+++ b/src/pages/__tests__/login.test.js
@@ -194,11 +194,42 @@ describe('LoginForm', () => {
             login: () => {},
             twoFAVerificationRequired: false,
             cancelTwoFA: () => {},
-            error: { httpStatusCode: 401 },
+            error: { details: { httpStatusCode: 401 } },
         })
         render(<LoginFormContainer />)
 
         expect(screen.getByText('Incorrect username or password')).toBeVisible()
+    })
+
+    it('shows something went wrong on error if 501 error, with message ', () => {
+        useLogin.mockReturnValue({
+            login: () => {},
+            twoFAVerificationRequired: false,
+            cancelTwoFA: () => {},
+            error: {
+                details: { httpStatusCode: 501 },
+                message: 'Sorry about that',
+            },
+        })
+        render(<LoginFormContainer />)
+
+        expect(screen.getByText('Something went wrong')).toBeVisible()
+        expect(screen.getByText('Sorry about that')).toBeVisible()
+    })
+
+    it('shows something went wrong if status code is not defined by error', () => {
+        useLogin.mockReturnValue({
+            login: () => {},
+            twoFAVerificationRequired: false,
+            cancelTwoFA: () => {},
+            error: { message: "I'm not a teapot, I'm an error message" },
+        })
+        render(<LoginFormContainer />)
+
+        expect(screen.getByText('Something went wrong')).toBeVisible()
+        expect(
+            screen.getByText("I'm not a teapot, I'm an error message")
+        ).toBeVisible()
     })
 
     it('does not show inputs if login function is not defined ', () => {

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -159,7 +159,8 @@ const LoginForm = ({
             {error && (
                 <FormNotice
                     title={
-                        error.httpStatusCode >= 500
+                        !error?.details?.httpStatusCode ||
+                        error.details.httpStatusCode >= 500
                             ? i18n.t('Something went wrong', {
                                   lng: uiLocale,
                               })
@@ -169,7 +170,8 @@ const LoginForm = ({
                     }
                     error
                 >
-                    {!error.httpStatusCode >= 500 && (
+                    {(!error?.details?.httpStatusCode ||
+                        error.details.httpStatusCode >= 500) && (
                         <span>{error?.message}</span>
                     )}
                 </FormNotice>


### PR DESCRIPTION
See ticket: https://dhis2.atlassian.net/browse/DHIS2-17433

This corrects the logic to show indeterminate "Something went wrong" error message. We made a decision in design to generally show "Incorrect username or password", but if we have a 500 range error, this is not appropriate. Previously the code was checking error.httpStatusCode, but the code is actually at error.details.httpStatusCode. Code has also been updated to handle cases where error does not have details (e.g. because you're offline or server is not available).