### PR TITLE
feat: pass hash path with redirect [DHIS2-17629]

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -114,7 +114,7 @@ export const AppContent = () => {
 
 const App = () => (
     <HashRouter>
-        <LoginConfigProvider>
+        <LoginConfigProvider initialLocation={window?.location?.href}>
             <CssReset />
             <CssVariables colors spacers theme elevations />
             <AppContent />

--- a/src/helpers/__tests__/getHashFromLocation.test.js
+++ b/src/helpers/__tests__/getHashFromLocation.test.js
@@ -1,0 +1,41 @@
+import { getHashFromLocation } from '../getHashFromLocation.js'
+
+const loginHashLocations = [
+    'create-account',
+    'complete-registration',
+    'reset-password',
+    'update-password',
+    'safeMode',
+    'download',
+]
+
+describe('getHashFromLocation', () => {
+    it('returns undefined if location is undefined', () => {
+        const hashPath = getHashFromLocation()
+        expect(hashPath).toBe(undefined)
+    })
+
+    it('returns everything after from first occurence of #/', () => {
+        const hashPath = getHashFromLocation(
+            'https://anInstance.org/path/to/app/#/?param1=val&param2#/thisShouldNotHappen'
+        )
+        expect(hashPath).toBe('#/?param1=val&param2#/thisShouldNotHappen')
+    })
+
+    it('returns undefined when initial url does not have a hash location', () => {
+        const hashPath = getHashFromLocation(
+            'https://anInstance.org/path/to/app/that/does/not/contain/a/hash/path'
+        )
+        expect(hashPath).toBe(undefined)
+    })
+
+    it.each(loginHashLocations)(
+        'if hash path starts with %p, returns undefined',
+        (reservedHashPath) => {
+            const hashPath = getHashFromLocation(
+                `http://myDhis2.org/path/to/app/#/${reservedHashPath}?andThen=somethingElse`
+            )
+            expect(hashPath).toEqual(undefined)
+        }
+    )
+})

--- a/src/helpers/__tests__/redirectHelpers.test.js
+++ b/src/helpers/__tests__/redirectHelpers.test.js
@@ -41,4 +41,14 @@ describe('getRedirectString', () => {
         })
         expect(redirectString).toBe('path/toHere')
     })
+
+    it('includes hashRedirect if provided', () => {
+        // Set the variables
+        const redirectString = getRedirectString({
+            response: { redirectUrl: 'somewhere' },
+            baseUrl: 'path/',
+            hashRedirect: '#/withHash=true',
+        })
+        expect(redirectString).toBe('somewhere#/withHash=true')
+    })
 })

--- a/src/helpers/getHashFromLocation.js
+++ b/src/helpers/getHashFromLocation.js
@@ -1,0 +1,26 @@
+export const getHashFromLocation = (initialLocation) => {
+    if (!initialLocation) {
+        return undefined
+    }
+    if (initialLocation.indexOf('#/') === -1) {
+        return undefined
+    }
+    const initialHashExtension = initialLocation.substring(
+        initialLocation.indexOf('#/') + 2
+    )
+
+    // we check and exclude hash locations used by the login app
+    const loginHashLocations = [
+        'create-account',
+        'complete-registration',
+        'reset-password',
+        'update-password',
+        'safeMode',
+        'download',
+    ]
+    return loginHashLocations.some((excludedLocation) =>
+        initialHashExtension?.startsWith(excludedLocation)
+    )
+        ? undefined
+        : `#/${initialHashExtension}`
+}

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,3 +1,4 @@
 export { checkIsLoginFormValid, getIsRequired } from './validators.js'
 export { convertHTML, removeHTMLTags, sanitizeMainHTML } from './handleHTML.js'
 export { redirectTo, getRedirectString } from './redirectHelpers.js'
+export { getHashFromLocation } from './getHashFromLocation.js'

--- a/src/helpers/redirectHelpers.js
+++ b/src/helpers/redirectHelpers.js
@@ -1,8 +1,14 @@
-export const getRedirectString = ({ response, baseUrl }) => {
+export const getRedirectString = ({ response, baseUrl, hashRedirect }) => {
     if (process.env.NODE_ENV === 'development') {
-        return baseUrl + response?.redirectUrl
+        return (
+            baseUrl +
+            response?.redirectUrl +
+            (hashRedirect ? `#/${hashRedirect}` : '')
+        )
     }
-    return response.redirectUrl ? `${response.redirectUrl}` : baseUrl
+    return response.redirectUrl
+        ? `${response.redirectUrl}${hashRedirect ? '#/' + hashRedirect : ''}`
+        : baseUrl
 }
 
 export const redirectTo = (redirectDestination) => {

--- a/src/helpers/redirectHelpers.js
+++ b/src/helpers/redirectHelpers.js
@@ -1,13 +1,9 @@
 export const getRedirectString = ({ response, baseUrl, hashRedirect }) => {
     if (process.env.NODE_ENV === 'development') {
-        return (
-            baseUrl +
-            response?.redirectUrl +
-            (hashRedirect ? `#/${hashRedirect}` : '')
-        )
+        return baseUrl + response?.redirectUrl + (hashRedirect ?? '')
     }
     return response.redirectUrl
-        ? `${response.redirectUrl}${hashRedirect ? '#/' + hashRedirect : ''}`
+        ? `${response.redirectUrl}${hashRedirect ?? ''}`
         : baseUrl
 }
 

--- a/src/hooks/useLogin.js
+++ b/src/hooks/useLogin.js
@@ -25,7 +25,7 @@ const loginMutation = {
 }
 
 export const useLogin = () => {
-    const { baseUrl } = useLoginConfig()
+    const { baseUrl, hashRedirect } = useLoginConfig()
     const [loginStatus, setLoginStatus] = useState(null)
     const [error, setError] = useState(null)
 
@@ -46,7 +46,11 @@ export const useLogin = () => {
         )
 
         if (response.loginStatus === LOGIN_STATUSES.success) {
-            const redirectString = getRedirectString({ response, baseUrl })
+            const redirectString = getRedirectString({
+                response,
+                baseUrl,
+                hashRedirect,
+            })
             redirectTo(redirectString)
         }
     }

--- a/src/providers/__tests__/use-login-config.test.js
+++ b/src/providers/__tests__/use-login-config.test.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/prop-types */
 import { renderHook } from '@testing-library/react-hooks'
 import React from 'react'
 import { LoginConfigProvider } from '../login-config-provider.js'
@@ -67,6 +68,15 @@ describe('useAppContext', () => {
     const wrapper = ({ children }) => (
         <LoginConfigProvider>{children}</LoginConfigProvider>
     )
+
+    const createWrapperWithLocation = ({ initialLocation }) => {
+        const WrapperWithLocation = ({ children }) => (
+            <LoginConfigProvider initialLocation={initialLocation}>
+                {children}
+            </LoginConfigProvider>
+        )
+        return WrapperWithLocation
+    }
 
     afterEach(() => {
         jest.clearAllMocks()
@@ -177,5 +187,20 @@ describe('useAppContext', () => {
         expect(result.current.applicationTitle).toBe(
             'Guía del autoestopista DHIS2'
         )
+    })
+
+    it('has hashRedirect location as undefined by default', () => {
+        const { result } = renderHook(() => useLoginConfig(), { wrapper })
+        expect(result.current.hashRedirect).toBe(undefined)
+    })
+
+    it('has hashRedirect determined provided window location', () => {
+        const { result } = renderHook(() => useLoginConfig(), {
+            wrapper: createWrapperWithLocation({
+                initialLocation:
+                    'https://myInstance.org/path/to/myApp/#/hashpath',
+            }),
+        })
+        expect(result.current.hashRedirect).toBe('#/hashpath')
     })
 })

--- a/src/providers/login-config-context.js
+++ b/src/providers/login-config-context.js
@@ -16,6 +16,7 @@ const LoginConfigContext = createContext({
     localesUI: [],
     refreshOnTranslation: 'undefined (function)',
     defaultLoginPageLogo: './api/staticContent/logo_front',
+    hashRedirect: undefined,
 })
 
 export { LoginConfigContext }

--- a/src/providers/login-config-provider.js
+++ b/src/providers/login-config-provider.js
@@ -3,6 +3,7 @@ import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import { Loader } from '../components/loader.js'
+import { getHashFromLocation } from '../helpers/index.js'
 import { LoginConfigContext } from './login-config-context.js'
 
 const localStorageLocaleKey = 'dhis2.locale.ui'
@@ -55,20 +56,7 @@ const LoginConfigProvider = ({ initialLocation, children }) => {
     } = useDataQuery(localesQuery)
     const config = useConfig()
 
-    const initialHashExtension = initialLocation?.split('#')?.[1]?.substring(1)
-    const loginHashLocations = [
-        'create-account',
-        'complete-registration',
-        'reset-password',
-        'update-password',
-        'safeMode',
-        'download',
-    ]
-    const hashRedirect = loginHashLocations.some((excludedLocation) =>
-        initialHashExtension?.startsWith(excludedLocation)
-    )
-        ? undefined
-        : initialHashExtension
+    const hashRedirect = getHashFromLocation(initialLocation)
 
     const [translatedValues, setTranslatedValues] = useState()
 

--- a/src/providers/login-config-provider.js
+++ b/src/providers/login-config-provider.js
@@ -40,7 +40,7 @@ const defaultLocales = [
     { locale: 'es', displayName: 'Spanish', name: 'español' },
 ]
 
-const LoginConfigProvider = ({ children }) => {
+const LoginConfigProvider = ({ initialLocation, children }) => {
     const {
         data: loginConfigData,
         loading: loginConfigLoading,
@@ -54,6 +54,21 @@ const LoginConfigProvider = ({ children }) => {
         error: localesError,
     } = useDataQuery(localesQuery)
     const config = useConfig()
+
+    const initialHashExtension = initialLocation?.split('#')?.[1]?.substring(1)
+    const loginHashLocations = [
+        'create-account',
+        'complete-registration',
+        'reset-password',
+        'update-password',
+        'safeMode',
+        'download',
+    ]
+    const hashRedirect = loginHashLocations.some((excludedLocation) =>
+        initialHashExtension?.startsWith(excludedLocation)
+    )
+        ? undefined
+        : initialHashExtension
 
     const [translatedValues, setTranslatedValues] = useState()
 
@@ -116,6 +131,7 @@ const LoginConfigProvider = ({ children }) => {
 
     const providerValue = {
         ...loginConfigData?.loginConfig,
+        hashRedirect,
         ...translatedValues,
         localesUI: localesData?.localesUI ?? defaultLocales,
         systemLocale: loginConfigData?.loginConfig?.uiLocale ?? 'en',
@@ -132,6 +148,7 @@ const LoginConfigProvider = ({ children }) => {
 
 LoginConfigProvider.propTypes = {
     children: PropTypes.node.isRequired,
+    initialLocation: PropTypes.string,
 }
 
 export { LoginConfigProvider }


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-17629?jql=project%20%3D%20%22DHIS2%22%20ORDER%20BY%20created%20DESC

This PR adds logic to:
1. record the initial location when the login app is loaded 
2. extract the hash path from that initial location
3. append the hash path (if applicable) to the redirect URL

The goal is so that when you get redirected from the data entry app to the login app with the hash path left in place (e.g. https://debug.dhis2.org/dev/dhis-web-login/#/?dataSetId=V8MHeZHIrcP&orgUnitId=ImspTQPwCqd&periodId=2020), then the app will remember the has path `#/?dataSetId=V8MHeZHIrcP&orgUnitId=ImspTQPwCqd&periodId=2020` and redirect you to this (the hash path is not available to the server, so it has to be handled client-side).

Some notes for the implemented logic:
- anything from `#/` is considered to be the hash path (so this will pick up any subsequent `#` symbols for example)
- the extracted hash path is appended to the redirect url (relying on the backend to send the "correct" location and path for the first path of the redirect)
- if location has no hash path (no match on `#/`) or if the hash path is a path used by the login app, then there is nothing appended to the redirect url provided by the backend.

**Automated tests:** a number of tests have been added 
**Manual tests:** I tested against debug (with a production build of the app), and it behaved as expected.