### PR TITLE
fix: fall back to overall language [DHIS2-17696]

### DIFF
--- a/src/components/__tests__/customizable-elements.test.js
+++ b/src/components/__tests__/customizable-elements.test.js
@@ -102,14 +102,16 @@ describe('ApplicationRightFooter', () => {
 describe('PoweredByDHIS2', () => {
     it('displays in translation', () => {
         useLoginConfig.mockReturnValue({
-            uiLocale: 'id',
+            lngs: ['id', 'en'],
         })
         const i18Spy = jest
             .spyOn(i18n, 't')
             .mockReturnValue('Dipersembahkan oleh DHIS2')
         render(<PoweredByDHIS2 />)
         expect(i18Spy).toHaveBeenCalled()
-        expect(i18Spy).toHaveBeenCalledWith('Powered by DHIS2', { lng: 'id' })
+        expect(i18Spy).toHaveBeenCalledWith('Powered by DHIS2', {
+            lngs: ['id', 'en'],
+        })
         expect(
             screen.getByText('Dipersembahkan oleh DHIS2')
         ).toBeInTheDocument()

--- a/src/components/account-creation-form.js
+++ b/src/components/account-creation-form.js
@@ -46,26 +46,26 @@ AccountFormSection.propTypes = {
     title: PropTypes.string,
 }
 
-const RecaptchaWarning = ({ uiLocale }) => (
+const RecaptchaWarning = ({ lngs }) => (
     <div className={styles.recaptchaWarning}>
         <IconErrorFilled24 color={colors.red500} />
         <div className={styles.recaptchaWarningText}>
             {i18n.t(
                 'Please confirm that you are not a robot by checking the checkbox.',
-                { lng: uiLocale }
+                { lngs }
             )}
         </div>
     </div>
 )
 
 RecaptchaWarning.propTypes = {
-    uiLocale: PropTypes.string,
+    lngs: PropTypes.arrayOf(PropTypes.string),
 }
 
 const InnerCreateAccountForm = ({
     handleSubmit,
-    uiLocale,
     loading,
+    lngs,
     prepopulatedFields,
     emailConfigured,
     recaptchaSite,
@@ -73,16 +73,14 @@ const InnerCreateAccountForm = ({
     recaptchaError,
     selfRegistrationNoRecaptcha,
 }) => {
-    const isRequired = getIsRequired(uiLocale)
+    const isRequired = getIsRequired(lngs?.[0])
     return (
         <form onSubmit={handleSubmit}>
             <div>
-                <AccountFormSection
-                    title={i18n.t('Log in details', { lng: uiLocale })}
-                >
+                <AccountFormSection title={i18n.t('Log in details', { lngs })}>
                     <ReactFinalForm.Field
                         name="username"
-                        label={i18n.t('Username', { lng: uiLocale })}
+                        label={i18n.t('Username', { lngs })}
                         component={InputFieldFF}
                         className={styles.inputField}
                         validate={composeValidators(isRequired, dhis2Username)}
@@ -93,7 +91,7 @@ const InnerCreateAccountForm = ({
                     />
                     <ReactFinalForm.Field
                         name="password"
-                        label={i18n.t('Password', { lng: uiLocale })}
+                        label={i18n.t('Password', { lngs })}
                         component={InputFieldFF}
                         className={styles.inputField}
                         validate={composeValidators(isRequired, dhis2Password)}
@@ -105,11 +103,11 @@ const InnerCreateAccountForm = ({
                     />
                 </AccountFormSection>
                 <AccountFormSection
-                    title={i18n.t('Personal details', { lng: uiLocale })}
+                    title={i18n.t('Personal details', { lngs })}
                 >
                     <ReactFinalForm.Field
                         name="firstName"
-                        label={i18n.t('First name', { lng: uiLocale })}
+                        label={i18n.t('First name', { lngs })}
                         component={InputFieldFF}
                         className={styles.inputField}
                         validate={composeValidators(
@@ -120,7 +118,7 @@ const InnerCreateAccountForm = ({
                     />
                     <ReactFinalForm.Field
                         name="surname"
-                        label={i18n.t('Last name', { lng: uiLocale })}
+                        label={i18n.t('Last name', { lngs })}
                         component={InputFieldFF}
                         className={styles.inputField}
                         validate={composeValidators(
@@ -131,7 +129,7 @@ const InnerCreateAccountForm = ({
                     />
                     <ReactFinalForm.Field
                         name="email"
-                        label={i18n.t('Email', { lng: uiLocale })}
+                        label={i18n.t('Email', { lngs })}
                         component={InputFieldFF}
                         className={styles.inputField}
                         validate={composeValidators(isRequired, email)}
@@ -142,7 +140,7 @@ const InnerCreateAccountForm = ({
                     {!emailConfigured && (
                         <ReactFinalForm.Field
                             name="phoneNumber"
-                            label={i18n.t('Phone number', { lng: uiLocale })}
+                            label={i18n.t('Phone number', { lngs })}
                             component={InputFieldFF}
                             className={styles.inputField}
                             validate={composeValidators(
@@ -158,7 +156,7 @@ const InnerCreateAccountForm = ({
                         <ReCAPTCHA
                             ref={recaptchaRef}
                             sitekey={recaptchaSite}
-                            hl={uiLocale}
+                            hl={lngs?.[0] ?? 'en'}
                         />
                         {recaptchaError && <RecaptchaWarning />}
                     </AccountFormSection>
@@ -167,12 +165,10 @@ const InnerCreateAccountForm = ({
             <ButtonStrip>
                 <Button primary type="submit" disabled={loading}>
                     {loading
-                        ? i18n.t('Creating...', { lng: uiLocale })
-                        : i18n.t('Create account', { lng: uiLocale })}
+                        ? i18n.t('Creating...', { lngs })
+                        : i18n.t('Create account', { lngs })}
                 </Button>
-                <BackToLoginButton
-                    buttonText={i18n.t('Cancel', { lng: uiLocale })}
-                />
+                <BackToLoginButton buttonText={i18n.t('Cancel', { lngs })} />
             </ButtonStrip>
         </form>
     )
@@ -181,13 +177,13 @@ const InnerCreateAccountForm = ({
 InnerCreateAccountForm.propTypes = {
     emailConfigured: PropTypes.bool,
     handleSubmit: PropTypes.func,
+    lngs: PropTypes.arrayOf(PropTypes.string),
     loading: PropTypes.bool,
     prepopulatedFields: PropTypes.object,
     recaptchaError: PropTypes.bool,
     recaptchaRef: PropTypes.node,
     recaptchaSite: PropTypes.string,
     selfRegistrationNoRecaptcha: PropTypes.bool,
-    uiLocale: PropTypes.string,
 }
 
 export const CreateAccountForm = ({
@@ -203,7 +199,7 @@ export const CreateAccountForm = ({
     // depends on https://dhis2.atlassian.net/browse/DHIS2-14615
     const {
         applicationTitle,
-        uiLocale,
+        lngs,
         emailConfigured,
         recaptchaSite,
         selfRegistrationNoRecaptcha,
@@ -225,7 +221,7 @@ export const CreateAccountForm = ({
                         {i18n.t(
                             'Enter your details below to create a {{- applicationName}} account.',
                             {
-                                lng: uiLocale,
+                                lngs,
                                 applicationName:
                                     removeHTMLTags(applicationTitle),
                             }
@@ -234,11 +230,9 @@ export const CreateAccountForm = ({
                     {createType === CREATE_FORM_TYPES.create && (
                         <p>
                             {i18n.t('Already have an account?', {
-                                lng: uiLocale,
+                                lngs,
                             })}{' '}
-                            <Link to="/">
-                                {i18n.t('Log in.', { lng: uiLocale })}
-                            </Link>
+                            <Link to="/">{i18n.t('Log in.', { lngs })}</Link>
                         </p>
                     )}
                 </FormSubtitle>
@@ -249,7 +243,7 @@ export const CreateAccountForm = ({
                     <FormNotice
                         title={i18n.t(
                             'Something went wrong, and we could not register your account',
-                            { lng: uiLocale }
+                            { lngs }
                         )}
                         error={true}
                     >
@@ -260,14 +254,14 @@ export const CreateAccountForm = ({
                     <>
                         <FormNotice
                             title={i18n.t('Account created successfully', {
-                                lng: uiLocale,
+                                lngs,
                             })}
                             valid
                         >
                             <span>
                                 {i18n.t(
                                     'You can use your username and password to log in.',
-                                    { lng: uiLocale }
+                                    { lngs }
                                 )}
                             </span>
                         </FormNotice>
@@ -279,7 +273,7 @@ export const CreateAccountForm = ({
                         {({ handleSubmit }) => (
                             <InnerCreateAccountForm
                                 handleSubmit={handleSubmit}
-                                uiLocale={uiLocale}
+                                lngs={lngs}
                                 loading={loading}
                                 prepopulatedFields={prepopulatedFields}
                                 emailConfigured={emailConfigured}

--- a/src/components/customizable-elements.js
+++ b/src/components/customizable-elements.js
@@ -60,7 +60,7 @@ export const ApplicationRightFooter = () => {
 }
 
 export const PoweredByDHIS2 = () => {
-    const { uiLocale } = useLoginConfig()
+    const { lngs } = useLoginConfig()
     return (
         <span>
             <bdi>
@@ -69,7 +69,7 @@ export const PoweredByDHIS2 = () => {
                     rel="noopener noreferrer"
                     target="_blank"
                 >
-                    {i18n.t('Powered by DHIS2', { lng: uiLocale })}
+                    {i18n.t('Powered by DHIS2', { lngs })}
                 </a>
             </bdi>
         </span>

--- a/src/components/login-links.js
+++ b/src/components/login-links.js
@@ -10,7 +10,7 @@ export const LoginLinks = ({ formUserName }) => {
         allowAccountRecovery,
         emailConfigured,
         selfRegistrationEnabled,
-        uiLocale,
+        lngs,
     } = useLoginConfig()
 
     return (
@@ -25,15 +25,15 @@ export const LoginLinks = ({ formUserName }) => {
                                     : `/reset-password`
                             }
                         >
-                            {i18n.t('Forgot password?', { lng: uiLocale })}
+                            {i18n.t('Forgot password?', { lngs })}
                         </Link>
                     </span>
                 )}
                 {selfRegistrationEnabled && (
                     <span>
-                        {i18n.t("Don't have an account?", { lng: uiLocale })}{' '}
+                        {i18n.t("Don't have an account?", { lngs })}{' '}
                         <Link to="/create-account">
-                            {i18n.t('Create an account', { lng: uiLocale })}
+                            {i18n.t('Create an account', { lngs })}
                         </Link>
                     </span>
                 )}

--- a/src/components/not-allowed-notice.js
+++ b/src/components/not-allowed-notice.js
@@ -5,13 +5,13 @@ import { BackToLoginButton } from './back-to-login-button.js'
 import { FormContainer } from './form-container.js'
 import { FormNotice } from './form-notice.js'
 
-export const NotAllowedNotice = ({ uiLocale }) => (
+export const NotAllowedNotice = ({ lngs }) => (
     <FormContainer>
         <FormNotice error>
             <span>
                 {i18n.t(
                     'The requested page is not configured for your system',
-                    { lng: uiLocale }
+                    { lngs }
                 )}
             </span>
         </FormNotice>
@@ -20,19 +20,19 @@ export const NotAllowedNotice = ({ uiLocale }) => (
 )
 
 NotAllowedNotice.propTypes = {
-    uiLocale: PropTypes.string,
+    lngs: PropTypes.arrayOf(PropTypes.string),
 }
 
-export const NotAllowedNoticeCreateAccount = ({ uiLocale }) => (
+export const NotAllowedNoticeCreateAccount = ({ lngs }) => (
     <FormContainer>
         <FormNotice
             error
-            title={i18n.t('Creating account not available', { lng: uiLocale })}
+            title={i18n.t('Creating account not available', { lngs })}
         >
             <span>
                 {i18n.t(
                     'Contact a system administrator to create an account.',
-                    { lng: uiLocale }
+                    { lngs }
                 )}
             </span>
         </FormNotice>
@@ -41,5 +41,5 @@ export const NotAllowedNoticeCreateAccount = ({ uiLocale }) => (
 )
 
 NotAllowedNoticeCreateAccount.propTypes = {
-    uiLocale: PropTypes.string,
+    lngs: PropTypes.arrayOf(PropTypes.string),
 }

--- a/src/components/oidc-login-options.js
+++ b/src/components/oidc-login-options.js
@@ -26,7 +26,7 @@ const redirectToOIDC = ({ baseUrl, endpoint }) => {
 }
 
 export const OIDCLoginOptions = () => {
-    const { oidcProviders, baseUrl, uiLocale } = useLoginConfig()
+    const { oidcProviders, baseUrl, lngs } = useLoginConfig()
     if (!(oidcProviders?.length > 0)) {
         return null
     }
@@ -42,7 +42,7 @@ export const OIDCLoginOptions = () => {
                 >
                     {loginTextStrings[oidc?.loginText]
                         ? i18n.t(loginTextStrings[oidc.loginText], {
-                              lng: uiLocale,
+                              lngs,
                           })
                         : oidc?.loginText}
                 </Button>

--- a/src/helpers/__tests__/locales.test.js
+++ b/src/helpers/__tests__/locales.test.js
@@ -1,0 +1,22 @@
+import { parseLocale, getLngsArray } from '../locales.js'
+
+describe('parseLocale', () => {
+    it('handles one _', () => {
+        expect(parseLocale('en_LK')).toBe('en-LK')
+    })
+    it('handles multiple _', () => {
+        expect(parseLocale('mn_MN_Cyrl')).toBe('mn-MN-Cyrl')
+    })
+    it('handles no _', () => {
+        expect(parseLocale('id')).toBe('id')
+    })
+})
+
+describe('getLngsArray', () => {
+    it('adds language from multipart locale', () => {
+        expect(getLngsArray('fr_CA')).toEqual(['fr_CA', 'fr'])
+    })
+    it('returns array with just language when locale is only language', () => {
+        expect(getLngsArray('fr')).toEqual(['fr'])
+    })
+})

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,3 +1,4 @@
 export { checkIsLoginFormValid, getIsRequired } from './validators.js'
 export { convertHTML, removeHTMLTags, sanitizeMainHTML } from './handleHTML.js'
 export { redirectTo, getRedirectString } from './redirectHelpers.js'
+export { parseLocale, getLngsArray } from './locales.js'

--- a/src/helpers/locales.js
+++ b/src/helpers/locales.js
@@ -1,0 +1,7 @@
+export const parseLocale = (unparsedLocale) =>
+    unparsedLocale?.replaceAll('_', '-')
+
+export const getLngsArray = (locale) => {
+    const [lng] = locale.split('_')
+    return lng === locale ? [locale] : [locale, lng]
+}

--- a/src/helpers/validators.js
+++ b/src/helpers/validators.js
@@ -1,7 +1,7 @@
 import i18n from '@dhis2/d2-i18n'
 
-export const getIsRequired = (uiLocale) => (val) =>
-    val ? undefined : i18n.t('This field is required', { lng: uiLocale })
+export const getIsRequired = (lng) => (val) =>
+    val ? undefined : i18n.t('This field is required', { lng })
 
 export const checkIsLoginFormValid = (values) => {
     const isRequired = getIsRequired('en') // 'en' because we do not need the actual translation for validation test

--- a/src/pages/complete-registration.js
+++ b/src/pages/complete-registration.js
@@ -20,7 +20,7 @@ const selfRegisterMutation = {
     data: (data) => data,
 }
 
-const CompleteRegistrationFormWrapper = ({ uiLocale }) => {
+const CompleteRegistrationFormWrapper = ({ lngs }) => {
     // depends on https://dhis2.atlassian.net/browse/DHIS2-14617
     const { selfRegistrationNoRecaptcha } = useLoginConfig()
     const recaptchaRef = useRef()
@@ -39,7 +39,7 @@ const CompleteRegistrationFormWrapper = ({ uiLocale }) => {
                 <FormNotice
                     error={true}
                     title={i18n.t('Cannot process registration', {
-                        lng: uiLocale,
+                        lngs,
                     })}
                 >
                     <span>
@@ -90,24 +90,24 @@ const CompleteRegistrationFormWrapper = ({ uiLocale }) => {
 }
 
 CompleteRegistrationFormWrapper.propTypes = {
-    uiLocale: PropTypes.string,
+    lngs: PropTypes.arrayOf(PropTypes.string),
 }
 
 const requiredPropsForCreateAccount = ['emailConfigured']
 
 const CompleteRegistrationPage = () => {
-    const { uiLocale } = useLoginConfig()
+    const { lngs } = useLoginConfig()
     const { notAllowed } = useGetErrorIfNotAllowed(
         requiredPropsForCreateAccount
     )
 
     if (notAllowed) {
-        return <NotAllowedNotice uiLocale={uiLocale} />
+        return <NotAllowedNotice lngs={lngs} />
     }
 
     return (
-        <FormContainer title={i18n.t('Create account', { lng: uiLocale })}>
-            <CompleteRegistrationFormWrapper uiLocale={uiLocale} />
+        <FormContainer title={i18n.t('Create account', { lngs })}>
+            <CompleteRegistrationFormWrapper lngs={lngs} />
         </FormContainer>
     )
 }

--- a/src/pages/create-account.js
+++ b/src/pages/create-account.js
@@ -55,20 +55,17 @@ const CreateAccountFormWrapper = () => {
 const requiredPropsForCreateAccount = ['selfRegistrationEnabled']
 
 const CreateAccountPage = () => {
-    const { uiLocale } = useLoginConfig()
+    const { lngs } = useLoginConfig()
     const { notAllowed } = useGetErrorIfNotAllowed(
         requiredPropsForCreateAccount
     )
 
     if (notAllowed) {
-        return <NotAllowedNoticeCreateAccount uiLocale={uiLocale} />
+        return <NotAllowedNoticeCreateAccount lngs={lngs} />
     }
 
     return (
-        <FormContainer
-            title={i18n.t('Create account', { lng: uiLocale })}
-            variableWidth
-        >
+        <FormContainer title={i18n.t('Create account', { lngs })} variableWidth>
             <CreateAccountFormWrapper />
         </FormContainer>
     )

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -30,7 +30,7 @@ const InnerLoginForm = ({
     formSubmitted,
     twoFAVerificationRequired,
     cancelTwoFA,
-    uiLocale,
+    lngs,
     loading,
     setFormUserName,
 }) => {
@@ -44,12 +44,12 @@ const InnerLoginForm = ({
         ref?.current?.focus()
     }
     const loginButtonText = twoFAVerificationRequired
-        ? i18n.t('Verify and log in', { lng: uiLocale })
-        : i18n.t('Log in', { lng: uiLocale })
+        ? i18n.t('Verify and log in', { lngs })
+        : i18n.t('Log in', { lngs })
     const login2FAButtonText = twoFAVerificationRequired
-        ? i18n.t('Verifying...', { lng: uiLocale })
-        : i18n.t('Logging in...', { lng: uiLocale })
-    const isRequired = getIsRequired(uiLocale)
+        ? i18n.t('Verifying...', { lngs })
+        : i18n.t('Logging in...', { lngs })
+    const isRequired = getIsRequired(lngs[0])
     return (
         <form onSubmit={handleSubmit}>
             <div
@@ -60,7 +60,7 @@ const InnerLoginForm = ({
                 {/* onChange will not update every change, so may need to use controlled InputField here for username tracking */}
                 <ReactFinalForm.Field
                     name="username"
-                    label={i18n.t('Username', { lng: uiLocale })}
+                    label={i18n.t('Username', { lngs })}
                     component={InputFieldFF}
                     className={styles.inputField}
                     validate={!formSubmitted ? null : isRequired}
@@ -73,7 +73,7 @@ const InnerLoginForm = ({
                 />
                 <ReactFinalForm.Field
                     name="password"
-                    label={i18n.t('Password', { lng: uiLocale })}
+                    label={i18n.t('Password', { lngs })}
                     type="password"
                     component={InputFieldFF}
                     className={styles.inputField}
@@ -90,7 +90,7 @@ const InnerLoginForm = ({
             >
                 <ReactFinalForm.Field
                     name="twoFA"
-                    label={i18n.t('Authentication code', { lng: uiLocale })}
+                    label={i18n.t('Authentication code', { lngs })}
                     component={InputFieldFF}
                     className={styles.inputField}
                     initialValue=""
@@ -104,7 +104,7 @@ const InnerLoginForm = ({
                 </Button>
                 {twoFAVerificationRequired && (
                     <Button secondary disabled={loading} onClick={clearTwoFA}>
-                        {i18n.t('Cancel', { lng: uiLocale })}
+                        {i18n.t('Cancel', { lngs })}
                     </Button>
                 )}
             </div>
@@ -113,7 +113,7 @@ const InnerLoginForm = ({
 }
 
 InnerLoginForm.defaultProps = {
-    uiLocale: 'en',
+    lngs: ['en'],
 }
 
 InnerLoginForm.propTypes = {
@@ -121,9 +121,9 @@ InnerLoginForm.propTypes = {
     handleSubmit: PropTypes.func.isRequired,
     twoFAVerificationRequired: PropTypes.bool.isRequired,
     formSubmitted: PropTypes.bool,
+    lngs: PropTypes.arrayOf(PropTypes.string),
     loading: PropTypes.bool,
     setFormUserName: PropTypes.func,
-    uiLocale: PropTypes.string,
 }
 
 const LoginForm = ({
@@ -134,7 +134,7 @@ const LoginForm = ({
     error,
     loading,
     setFormUserName,
-    uiLocale,
+    lngs,
 }) => {
     const [formSubmitted, setFormSubmitted] = useState(false)
 
@@ -162,10 +162,10 @@ const LoginForm = ({
                         !error?.details?.httpStatusCode ||
                         error.details.httpStatusCode >= 500
                             ? i18n.t('Something went wrong', {
-                                  lng: uiLocale,
+                                  lngs,
                               })
                             : i18n.t('Incorrect username or password', {
-                                  lng: uiLocale,
+                                  lngs,
                               })
                     }
                     error
@@ -179,7 +179,7 @@ const LoginForm = ({
             {twoFAIncorrect && (
                 <FormNotice
                     title={i18n.t('Incorrect authentication code', {
-                        lng: uiLocale,
+                        lngs,
                     })}
                     error
                 />
@@ -192,7 +192,7 @@ const LoginForm = ({
                         twoFAVerificationRequired={twoFAVerificationRequired}
                         twoFAIncorrect={twoFAIncorrect}
                         cancelTwoFA={cancelTwoFA}
-                        uiLocale={uiLocale}
+                        lngs={lngs}
                         loading={loading}
                         setFormUserName={setFormUserName}
                     />
@@ -203,18 +203,18 @@ const LoginForm = ({
 }
 
 LoginForm.defaultProps = {
-    uiLocale: 'en',
+    lngs: ['en'],
 }
 
 LoginForm.propTypes = {
     cancelTwoFA: PropTypes.func,
     error: PropTypes.object,
+    lngs: PropTypes.arrayOf(PropTypes.string),
     loading: PropTypes.bool,
     login: PropTypes.func,
     setFormUserName: PropTypes.func,
     twoFAIncorrect: PropTypes.bool,
     twoFAVerificationRequired: PropTypes.bool,
-    uiLocale: PropTypes.string,
 }
 
 // this is set up this way to isolate styling from login form logic
@@ -228,14 +228,14 @@ export const LoginFormContainer = () => {
         loading,
     } = useLogin()
     const [formUserName, setFormUserName] = useState('')
-    const { uiLocale } = useLoginConfig()
+    const { lngs } = useLoginConfig()
 
     return (
         <FormContainer
             title={
                 twoFAVerificationRequired
-                    ? i18n.t('Two-factor authentication', { lng: uiLocale })
-                    : i18n.t('Log in', { lng: uiLocale })
+                    ? i18n.t('Two-factor authentication', { lngs })
+                    : i18n.t('Log in', { lngs })
             }
         >
             {twoFAVerificationRequired && (
@@ -243,14 +243,14 @@ export const LoginFormContainer = () => {
                     <p>
                         {i18n.t(
                             'Enter the code from your two-factor authentication app to log in.',
-                            { lng: uiLocale }
+                            { lngs }
                         )}
                     </p>
                 </FormSubtitle>
             )}
             <LoginForm
                 setFormUserName={setFormUserName}
-                uiLocale={uiLocale}
+                lngs={lngs}
                 login={login}
                 cancelTwoFA={cancelTwoFA}
                 twoFAVerificationRequired={twoFAVerificationRequired}

--- a/src/pages/password-reset-request.js
+++ b/src/pages/password-reset-request.js
@@ -26,7 +26,7 @@ const InnerPasswordResetRequestForm = ({
     handleSubmit,
     formSubmitted,
     isRequired,
-    uiLocale,
+    lngs,
     loading,
 }) => {
     const [params] = useSearchParams()
@@ -36,7 +36,7 @@ const InnerPasswordResetRequestForm = ({
             <div>
                 <ReactFinalForm.Field
                     name="emailOrUsername"
-                    label={i18n.t('Username or email', { lng: uiLocale })}
+                    label={i18n.t('Username or email', { lngs })}
                     component={InputFieldFF}
                     className={styles.inputField}
                     validate={!formSubmitted ? null : isRequired}
@@ -54,14 +54,14 @@ const InnerPasswordResetRequestForm = ({
                     primary
                 >
                     {loading
-                        ? i18n.t('Sending...', { lng: uiLocale })
+                        ? i18n.t('Sending...', { lngs })
                         : i18n.t('Send password reset request', {
-                              lng: uiLocale,
+                              lngs,
                           })}
                 </Button>
                 <BackToLoginButton
                     fullWidth
-                    buttonText={i18n.t('Cancel', { lng: uiLocale })}
+                    buttonText={i18n.t('Cancel', { lngs })}
                 />
             </div>
         </form>
@@ -72,16 +72,16 @@ InnerPasswordResetRequestForm.propTypes = {
     formSubmitted: PropTypes.bool,
     handleSubmit: PropTypes.func,
     isRequired: PropTypes.bool,
+    lngs: PropTypes.arrayOf(PropTypes.string),
     loading: PropTypes.bool,
-    uiLocale: PropTypes.string,
 }
 
-export const PasswordResetRequestForm = ({ uiLocale }) => {
+export const PasswordResetRequestForm = ({ lngs }) => {
     // depends on https://dhis2.atlassian.net/browse/DHIS2-14618
     const [resetPasswordRequest, { loading, fetching, error, data }] =
         useDataMutation(passwordResetRequestMutation)
     const [formSubmitted, setFormSubmitted] = useState(false)
-    const isRequired = getIsRequired(uiLocale)
+    const isRequired = getIsRequired(lngs?.[0])
 
     const handlePasswordResetRequest = (values) => {
         setFormSubmitted(true)
@@ -96,14 +96,14 @@ export const PasswordResetRequestForm = ({ uiLocale }) => {
             {error && (
                 <FormNotice
                     title={i18n.t('Password reset failed', {
-                        lng: uiLocale,
+                        lngs,
                     })}
                     error={true}
                 >
                     <span>
                         {i18n.t(
                             'Something went wrong. Please try again later, and contact your system administrator if the problem persists.',
-                            { lng: uiLocale }
+                            { lngs }
                         )}
                     </span>
                 </FormNotice>
@@ -114,7 +114,7 @@ export const PasswordResetRequestForm = ({ uiLocale }) => {
                         <span>
                             {i18n.t(
                                 'If the provided username or email is registered in the system, you will soon receive an email with a password reset link.',
-                                { lng: uiLocale }
+                                { lngs }
                             )}
                         </span>
                     </FormNotice>
@@ -128,7 +128,7 @@ export const PasswordResetRequestForm = ({ uiLocale }) => {
                             handleSubmit={handleSubmit}
                             formSubmitted={formSubmitted}
                             isRequired={isRequired}
-                            uiLocale={uiLocale}
+                            lngs={lngs}
                             loading={loading || fetching}
                         />
                     )}
@@ -139,11 +139,11 @@ export const PasswordResetRequestForm = ({ uiLocale }) => {
 }
 
 PasswordResetRequestForm.defaultProps = {
-    uiLocale: 'en',
+    lngs: ['en'],
 }
 
 PasswordResetRequestForm.propTypes = {
-    uiLocale: PropTypes.string,
+    lngs: PropTypes.arrayOf(PropTypes.string),
 }
 
 const requiredPropsForPasswordReset = [
@@ -152,26 +152,26 @@ const requiredPropsForPasswordReset = [
 ]
 
 const PasswordResetRequestPage = () => {
-    const { uiLocale } = useLoginConfig()
+    const { lngs } = useLoginConfig()
     const { notAllowed } = useGetErrorIfNotAllowed(
         requiredPropsForPasswordReset
     )
 
     if (notAllowed) {
-        return <NotAllowedNotice uiLocale={uiLocale} />
+        return <NotAllowedNotice lngs={lngs} />
     }
 
     return (
-        <FormContainer title={i18n.t('Reset password', { lng: uiLocale })}>
+        <FormContainer title={i18n.t('Reset password', { lngs })}>
             <FormSubtitle>
                 <p>
                     {i18n.t(
                         'Enter your username below, a link to reset your password will be sent to your registered e-mail.',
-                        { lng: uiLocale }
+                        { lngs }
                     )}
                 </p>
             </FormSubtitle>
-            <PasswordResetRequestForm uiLocale={uiLocale} />
+            <PasswordResetRequestForm lngs={lngs} />
         </FormContainer>
     )
 }

--- a/src/pages/password-update.js
+++ b/src/pages/password-update.js
@@ -23,8 +23,8 @@ const passwordUpdateMutation = {
     data: (data) => ({ ...data }),
 }
 
-const InnerPasswordUpdateForm = ({ handleSubmit, uiLocale, loading }) => {
-    const isRequired = getIsRequired(uiLocale)
+const InnerPasswordUpdateForm = ({ handleSubmit, lngs, loading }) => {
+    const isRequired = getIsRequired(lngs?.[0])
 
     return (
         <form onSubmit={handleSubmit}>
@@ -32,7 +32,7 @@ const InnerPasswordUpdateForm = ({ handleSubmit, uiLocale, loading }) => {
                 <ReactFinalForm.Field
                     name="password"
                     type="password"
-                    label={i18n.t('Password', { lng: uiLocale })}
+                    label={i18n.t('Password', { lngs })}
                     component={InputFieldFF}
                     className={styles.inputField}
                     validate={composeValidators(isRequired, dhis2Password)}
@@ -48,14 +48,12 @@ const InnerPasswordUpdateForm = ({ handleSubmit, uiLocale, loading }) => {
                     primary
                 >
                     {loading
-                        ? i18n.t('Saving...', { lng: uiLocale })
+                        ? i18n.t('Saving...', { lngs })
                         : i18n.t('Save new password', {
-                              lng: uiLocale,
+                              lngs,
                           })}
                 </Button>
-                <BackToLoginButton
-                    buttonText={i18n.t('Cancel', { lng: uiLocale })}
-                />
+                <BackToLoginButton buttonText={i18n.t('Cancel', { lngs })} />
             </div>
         </form>
     )
@@ -63,11 +61,11 @@ const InnerPasswordUpdateForm = ({ handleSubmit, uiLocale, loading }) => {
 
 InnerPasswordUpdateForm.propTypes = {
     handleSubmit: PropTypes.func,
+    lngs: PropTypes.arrayOf(PropTypes.string),
     loading: PropTypes.bool,
-    uiLocale: PropTypes.string,
 }
 
-export const PasswordUpdateForm = ({ token, uiLocale }) => {
+export const PasswordUpdateForm = ({ token, lngs }) => {
     // depends on https://dhis2.atlassian.net/browse/DHIS2-14618
     const [updatePassword, { loading, fetching, error, data }] =
         useDataMutation(passwordUpdateMutation)
@@ -82,14 +80,14 @@ export const PasswordUpdateForm = ({ token, uiLocale }) => {
                     {error && (
                         <FormNotice
                             title={i18n.t('New password not saved', {
-                                lng: uiLocale,
+                                lngs,
                             })}
                             error={true}
                         >
                             <span>
                                 {i18n.t(
                                     'There was a problem saving your password. Try again or contact your system administrator.',
-                                    { lng: uiLocale }
+                                    { lngs }
                                 )}
                             </span>
                         </FormNotice>
@@ -100,7 +98,7 @@ export const PasswordUpdateForm = ({ token, uiLocale }) => {
                                 <span>
                                     {i18n.t(
                                         'New password saved. You can use it to log in to your account.',
-                                        { lng: uiLocale }
+                                        { lngs }
                                     )}
                                 </span>
                             </FormNotice>
@@ -112,7 +110,7 @@ export const PasswordUpdateForm = ({ token, uiLocale }) => {
                             {({ handleSubmit }) => (
                                 <InnerPasswordUpdateForm
                                     handleSubmit={handleSubmit}
-                                    uiLocale={uiLocale}
+                                    lngs={lngs}
                                     loading={loading || fetching}
                                 />
                             )}
@@ -125,12 +123,12 @@ export const PasswordUpdateForm = ({ token, uiLocale }) => {
 }
 
 PasswordUpdateForm.defaultProps = {
-    uiLocale: 'en',
+    lngs: ['en'],
 }
 
 PasswordUpdateForm.propTypes = {
+    lngs: PropTypes.arrayOf(PropTypes.string),
     token: PropTypes.string,
-    uiLocale: PropTypes.string,
 }
 
 // presumably these would need to be allowed
@@ -140,7 +138,7 @@ const requiredPropsForPasswordReset = [
 ]
 
 const PasswordUpdatePage = () => {
-    const { uiLocale } = useLoginConfig()
+    const { lngs } = useLoginConfig()
     const [searchParams] = useSearchParams()
     const token = searchParams.get('token') || ''
     // display error if token is invalid?
@@ -149,19 +147,19 @@ const PasswordUpdatePage = () => {
     )
 
     if (notAllowed) {
-        return <NotAllowedNotice uiLocale={uiLocale} />
+        return <NotAllowedNotice lngs={lngs} />
     }
 
     return (
-        <FormContainer title={i18n.t('Choose new password', { lng: uiLocale })}>
+        <FormContainer title={i18n.t('Choose new password', { lngs })}>
             <FormSubtitle>
                 <p>
                     {i18n.t('Enter the new password for your account below', {
-                        lng: uiLocale,
+                        lngs,
                     })}
                 </p>
             </FormSubtitle>
-            <PasswordUpdateForm uiLocale={uiLocale} token={token} />
+            <PasswordUpdateForm lngs={lngs} token={token} />
         </FormContainer>
     )
 }

--- a/src/pages/safe-mode.js
+++ b/src/pages/safe-mode.js
@@ -6,7 +6,7 @@ import { useLoginConfig } from '../providers/index.js'
 const SAFE_MODE_ENDPOINT = 'dhis-web-commons/security/login.action'
 
 const SafeModePage = () => {
-    const { baseUrl, uiLocale } = useLoginConfig()
+    const { baseUrl, lngs } = useLoginConfig()
     const safeURL = `${baseUrl}/${SAFE_MODE_ENDPOINT}`
 
     useEffect(() => {
@@ -18,7 +18,7 @@ const SafeModePage = () => {
             <p>
                 {i18n.t(
                     'You should shortly be redirected. If you are not redirected, please click redirect button.',
-                    { lng: uiLocale }
+                    { lngs }
                 )}
             </p>
             <div>

--- a/src/providers/__tests__/use-login-config.test.js
+++ b/src/providers/__tests__/use-login-config.test.js
@@ -81,17 +81,19 @@ describe('useAppContext', () => {
     })
 
     // note: system language is English by default (if not provided by api)
-    it('updates uiLocale on translation, keeps systemLocale unchanged ', async () => {
+    it('updates uiLocale and lngs (with fallback language) on translation, keeps systemLocale unchanged ', async () => {
         const { result, waitForNextUpdate } = renderHook(
             () => useLoginConfig(),
             { wrapper }
         )
         expect(result.current.systemLocale).toBe('en')
         expect(result.current.uiLocale).toBe('en')
-        result.current.refreshOnTranslation({ locale: 'nb' })
+        expect(result.current.lngs).toEqual(['en'])
+        result.current.refreshOnTranslation({ locale: 'pt_BR' })
         await waitForNextUpdate()
         expect(result.current.systemLocale).toBe('en')
-        expect(result.current.uiLocale).toBe('nb')
+        expect(result.current.uiLocale).toBe('pt_BR')
+        expect(result.current.lngs).toEqual(['pt_BR', 'pt'])
     })
 
     it('updates translatable values on translation', async () => {
@@ -166,6 +168,21 @@ describe('useAppContext', () => {
         await waitForNextUpdate()
         expect(document.dir).toBe('rtl')
         result.current.refreshOnTranslation({ locale: 'fr' })
+        await waitForNextUpdate()
+        expect(document.dir).toBe('ltr')
+    })
+
+    it('updates document direction on refreshOnTranslation (if applicable) and handles locales', async () => {
+        const { result, waitForNextUpdate } = renderHook(
+            () => useLoginConfig(),
+            { wrapper }
+        )
+        // uiLocale is 'en' by default, hence dir is 'ltr'
+        expect(document.dir).toBe('ltr')
+        result.current.refreshOnTranslation({ locale: 'fa_IR' })
+        await waitForNextUpdate()
+        expect(document.dir).toBe('rtl')
+        result.current.refreshOnTranslation({ locale: 'fr_CA' })
         await waitForNextUpdate()
         expect(document.dir).toBe('ltr')
     })

--- a/src/providers/login-config-context.js
+++ b/src/providers/login-config-context.js
@@ -16,6 +16,7 @@ const LoginConfigContext = createContext({
     localesUI: [],
     refreshOnTranslation: 'undefined (function)',
     defaultLoginPageLogo: './api/staticContent/logo_front',
+    lngs: ['en'],
 })
 
 export { LoginConfigContext }

--- a/src/providers/login-config-provider.js
+++ b/src/providers/login-config-provider.js
@@ -3,6 +3,7 @@ import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useEffect, useState } from 'react'
 import { Loader } from '../components/loader.js'
+import { parseLocale, getLngsArray } from '../helpers/index.js'
 import { LoginConfigContext } from './login-config-context.js'
 
 const localStorageLocaleKey = 'dhis2.locale.ui'
@@ -63,8 +64,13 @@ const LoginConfigProvider = ({ children }) => {
             localStorage.getItem(localStorageLocaleKey) ||
             loginConfigData?.loginConfig?.uiLocale ||
             'en'
-        setTranslatedValues({ uiLocale: userLanguage })
-        i18n.changeLanguage(userLanguage)
+
+        setTranslatedValues({
+            uiLocale: userLanguage,
+            lngs: getLngsArray(userLanguage),
+        })
+        // direction will not be recognized if using a java-format locale code
+        i18n.changeLanguage(parseLocale(userLanguage))
         document.documentElement.setAttribute('dir', i18n.dir())
     }, []) //eslint-disable-line
 
@@ -82,8 +88,11 @@ const LoginConfigProvider = ({ children }) => {
         } catch (e) {
             console.error(e)
         }
-        i18n.changeLanguage(locale)
+        // direction will not be recognized if using a java-format locale code
+        i18n.changeLanguage(parseLocale(locale))
+
         document.documentElement.setAttribute('dir', i18n.dir())
+
         // the logic here is wrong as it falls back to previous translations (rather than defaults)
         // however, the api response will fall back to default system language (so this doesn't cause issues)
         const updatedTranslations = translatableValues.reduce(
@@ -97,7 +106,11 @@ const LoginConfigProvider = ({ children }) => {
             },
             {}
         )
-        setTranslatedValues({ ...updatedTranslations, uiLocale: locale }),
+        setTranslatedValues({
+            ...updatedTranslations,
+            uiLocale: locale,
+            lngs: getLngsArray(locale),
+        }),
             localStorage.setItem(localStorageLocaleKey, locale)
     }
 


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-17696

### Changes in PR:
- updates the translation wrapping so that the translations will fall back to the variant language if no specific translations (e.g. if you select Portuguese Brazilian, the translations should fall back to Portuguese if no pt_BR translation is available)
- handles the direction inference (which is based on i18n information) by parsing from Java format (e.g. `ar_EG`) to the ISO format expected by i18next (e.g. `ar-EG`)

**before**
<img width="1380" alt="image" src="https://github.com/dhis2/login-app/assets/18490902/bdcef6a4-c752-40bf-b21a-fce2618e6e02">
_(no translations for Egyptian Arabic and translations do not fall back to Arabic; direction is not set to RTL)_ 

**after**
<img width="1383" alt="image" src="https://github.com/dhis2/login-app/assets/18490902/af6e69ce-42d4-4619-8809-57cef7081271">
_(translations fall back to Arabic; direction is set to RTL)_

### Technical notes:
- the login app was already passing the user's chosen locale from the language selector to the i18n.t functions (with `lng` option). (This was done because calling i18n.changeLanguage would require a page refresh to load translations, which we decided against during the initial implementation). Since i18n.t also supports passing `lngs`, I've updated the translation functions to pass two languages (selected code and (if applicable) language e.g. `["ar_EG", "ar"]` or `["fr"]`)

### Testing
**Manual**: I've tested locally (looked at all pages in French) and visually checked that overall languages fallback to the overall language. You can see this on the main page looking at the differences between Portuguese Brazilian and Portuguese (slight difference in username, and Portuguese Brazilian did not have its own translation for "Create an account"

**Automated**: We don't generally test if strings are wrapped with translation logic, so I haven't done that here (it's an interesting question if it's possible 🧐). I have updated an existing test that touches translations in the "Powered by DHIS2" function and have updated tests for the relevant hooks to make sure fallback language gets set appropriately on language change. Also tests for the insignificant helper parser functions I added.