### PR TITLE
fix: handle missing login statuses [DHIS2-17773]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-07-23T09:32:21.891Z\n"
-"PO-Revision-Date: 2024-07-23T09:32:21.891Z\n"
+"POT-Creation-Date: 2024-07-23T11:23:34.551Z\n"
+"PO-Revision-Date: 2024-07-23T11:23:34.551Z\n"
 
 msgid "Please confirm that you are not a robot by checking the checkbox."
 msgstr "Please confirm that you are not a robot by checking the checkbox."
@@ -133,21 +133,6 @@ msgstr "Download default template"
 msgid "Download sidebar template"
 msgstr "Download sidebar template"
 
-msgid "Verify and log in"
-msgstr "Verify and log in"
-
-msgid "Log in"
-msgstr "Log in"
-
-msgid "Verifying..."
-msgstr "Verifying..."
-
-msgid "Logging in..."
-msgstr "Logging in..."
-
-msgid "Authentication code"
-msgstr "Authentication code"
-
 msgid "Something went wrong"
 msgstr "Something went wrong"
 
@@ -168,6 +153,21 @@ msgstr "Contact your system administrator."
 
 msgid "Account not accessible"
 msgstr "Account not accessible"
+
+msgid "Verify and log in"
+msgstr "Verify and log in"
+
+msgid "Log in"
+msgstr "Log in"
+
+msgid "Verifying..."
+msgstr "Verifying..."
+
+msgid "Logging in..."
+msgstr "Logging in..."
+
+msgid "Authentication code"
+msgstr "Authentication code"
 
 msgid "Two-factor authentication"
 msgstr "Two-factor authentication"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-03-19T14:31:01.861Z\n"
-"PO-Revision-Date: 2024-03-19T14:31:01.861Z\n"
+"POT-Creation-Date: 2024-07-23T09:32:21.891Z\n"
+"PO-Revision-Date: 2024-07-23T09:32:21.891Z\n"
 
 msgid "Please confirm that you are not a robot by checking the checkbox."
 msgstr "Please confirm that you are not a robot by checking the checkbox."
@@ -98,12 +98,6 @@ msgstr "Log in with Google"
 msgid "Log in with Microsoft"
 msgstr "Log in with Microsoft"
 
-msgid "Creating account not available"
-msgstr "Creating account not available"
-
-msgid "Contact a system administrator to create an account."
-msgstr "Contact a system administrator to create an account."
-
 msgid "I agree"
 msgstr "I agree"
 
@@ -151,12 +145,6 @@ msgstr "Verifying..."
 msgid "Logging in..."
 msgstr "Logging in..."
 
-msgid "Verifying..."
-msgstr "Verifying..."
-
-msgid "Logging in..."
-msgstr "Logging in..."
-
 msgid "Authentication code"
 msgstr "Authentication code"
 
@@ -168,8 +156,18 @@ msgstr "Incorrect username or password"
 
 msgid "Incorrect authentication code"
 msgstr "Incorrect authentication code"
-msgid "Incorrect authentication code"
-msgstr "Incorrect authentication code"
+
+msgid "Password expired"
+msgstr "Password expired"
+
+msgid "You can reset your from the password reset page."
+msgstr "You can reset your from the password reset page."
+
+msgid "Contact your system administrator."
+msgstr "Contact your system administrator."
+
+msgid "Account not accessible"
+msgstr "Account not accessible"
 
 msgid "Two-factor authentication"
 msgstr "Two-factor authentication"
@@ -183,8 +181,6 @@ msgstr "Username or email"
 msgid "Sending..."
 msgstr "Sending..."
 
-msgid "Send password reset request"
-msgstr "Send password reset request"
 msgid "Send password reset request"
 msgstr "Send password reset request"
 

--- a/src/hooks/__tests__/useLogin.test.js
+++ b/src/hooks/__tests__/useLogin.test.js
@@ -174,4 +174,21 @@ describe('useLogin', () => {
             expect(result.current.accountInaccessible).toBe(true)
         }
     )
+
+    it('sets unknownStatus to true after receiving an unexpected status', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onComplete({ loginStatus: 'I_AM_NEW_SURPRISE' })
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        act(() => {
+            result.current.login()
+        })
+        expect(result.current.loading).toBe(false)
+        expect(result.current.unknownStatus).toBe(true)
+    })
 })

--- a/src/hooks/__tests__/useLogin.test.js
+++ b/src/hooks/__tests__/useLogin.test.js
@@ -131,4 +131,47 @@ describe('useLogin', () => {
         expect(result.current.loading).toBe(false)
         expect(result.current.error).not.toBe(null)
     })
+
+    it('sets passwordExpired to true after receiving PASSWORD_EXPIRED', async () => {
+        useDataMutation.mockImplementation((mutation, options) => [
+            () => {
+                options.onComplete({ loginStatus: 'PASSWORD_EXPIRED' })
+            },
+            { loading: false },
+        ])
+
+        const { result } = renderHook(() => useLogin())
+        expect(result.current.loading).toBe(false)
+        act(() => {
+            result.current.login()
+        })
+        expect(result.current.loading).toBe(false)
+        expect(result.current.passwordExpired).toBe(true)
+    })
+
+    const inaccessibleStatuses = [
+        'ACCOUNT_DISABLED',
+        'ACCOUNT_EXPIRED',
+        'ACCOUNT_LOCKED',
+    ]
+
+    it.each(inaccessibleStatuses)(
+        'sets accountInaccessible to true after receiving %p',
+        (inaccessibleStatus) => {
+            useDataMutation.mockImplementation((mutation, options) => [
+                () => {
+                    options.onComplete({ loginStatus: inaccessibleStatus })
+                },
+                { loading: false },
+            ])
+
+            const { result } = renderHook(() => useLogin())
+            expect(result.current.loading).toBe(false)
+            act(() => {
+                result.current.login()
+            })
+            expect(result.current.loading).toBe(false)
+            expect(result.current.accountInaccessible).toBe(true)
+        }
+    )
 })

--- a/src/hooks/useLogin.js
+++ b/src/hooks/useLogin.js
@@ -96,5 +96,8 @@ export const useLogin = () => {
         twoFANotEnabled: loginStatus === LOGIN_STATUSES.notEnabled2fa,
         passwordExpired: loginStatus === LOGIN_STATUSES.passwordExpired,
         accountInaccessible: inaccessibleAccountStatuses.includes(loginStatus),
+        unknownStatus:
+            loginStatus !== null &&
+            !Object.values(LOGIN_STATUSES).includes(loginStatus),
     }
 }

--- a/src/hooks/useLogin.js
+++ b/src/hooks/useLogin.js
@@ -9,10 +9,19 @@ const LOGIN_STATUSES = {
     success: 'SUCCESS',
     secondAttempt2fa: 'second_attempt_incorrect_2fa', // this is internal logic to app
     success2fa: 'SUCCESS_2fa',
+    passwordExpired: 'PASSWORD_EXPIRED',
+    accountDisabled: 'ACCOUNT_DISABLED',
+    accountLocked: 'ACCOUNT_LOCKED',
+    accountExpired: 'ACCOUNT_EXPIRED',
 }
 const invalidTWOFA = [
     LOGIN_STATUSES.incorrect2fa,
     LOGIN_STATUSES.secondAttempt2fa,
+]
+const inaccessibleAccountStatuses = [
+    LOGIN_STATUSES.accountDisabled,
+    LOGIN_STATUSES.accountLocked,
+    LOGIN_STATUSES.accountExpired,
 ]
 
 const loginMutation = {
@@ -85,5 +94,7 @@ export const useLogin = () => {
             loginStatus === LOGIN_STATUSES.success2fa,
         twoFAIncorrect: loginStatus === LOGIN_STATUSES.secondAttempt2fa,
         twoFANotEnabled: loginStatus === LOGIN_STATUSES.notEnabled2fa,
+        passwordExpired: loginStatus === LOGIN_STATUSES.passwordExpired,
+        accountInaccessible: inaccessibleAccountStatuses.includes(loginStatus),
     }
 }

--- a/src/pages/__tests__/login.test.js
+++ b/src/pages/__tests__/login.test.js
@@ -355,4 +355,19 @@ describe('LoginForm', () => {
             screen.getByText('Contact your system administrator.')
         ).toBeInTheDocument()
     })
+
+    it('Shows Something went wrong if unknownStatus is true', () => {
+        useLogin.mockReturnValue({
+            login: () => {},
+            unknownStatus: true,
+            cancelTwoFA: () => {},
+        })
+
+        render(<LoginFormContainer />)
+
+        expect(screen.getByText('Something went wrong')).toBeInTheDocument()
+        expect(
+            screen.getByText('Contact your system administrator.')
+        ).toBeInTheDocument()
+    })
 })

--- a/src/pages/__tests__/login.test.js
+++ b/src/pages/__tests__/login.test.js
@@ -1,8 +1,10 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import React from 'react'
+import { MemoryRouter } from 'react-router-dom'
 import { checkIsLoginFormValid } from '../../helpers/validators.js'
 import { useLogin } from '../../hooks/useLogin.js'
+import { useLoginConfig } from '../../providers/use-login-config.js'
 import { LoginFormContainer } from '../login.js'
 
 jest.mock('../../helpers/validators.js', () => ({
@@ -17,6 +19,15 @@ jest.mock('../../hooks/useLogin.js', () => ({
         login: mockLogin,
         cancelTwoFA: () => {},
         twoFAVerificationRequired: false,
+        passwordExpired: false,
+        accountInaccessible: false,
+    })),
+}))
+
+jest.mock('../../providers/use-login-config.js', () => ({
+    useLoginConfig: jest.fn(() => ({
+        allowAccountRecovery: false,
+        emailConfigured: false,
     })),
 }))
 
@@ -261,5 +272,87 @@ describe('LoginForm', () => {
 
         expect(screen.getByText('LOGIN LINKS')).toBeInTheDocument()
         expect(screen.getByText('OIDC LOGIN OPTIONS')).toBeInTheDocument()
+    })
+
+    it('Shows link to password-reset page if passwordExpired and allowAccountRecovery and emailConfigured are true', () => {
+        useLogin.mockReturnValue({
+            login: () => {},
+            passwordExpired: true,
+            cancelTwoFA: () => {},
+        })
+        useLoginConfig.mockReturnValueOnce({
+            allowAccountRecovery: true,
+            emailConfigured: true,
+        })
+        // needs MemoryRouter because link is from react-router-dom
+        render(
+            <MemoryRouter>
+                <LoginFormContainer />
+            </MemoryRouter>
+        )
+
+        expect(screen.getByText('Password expired')).toBeInTheDocument()
+        expect(
+            screen.getByRole('link', {
+                name: 'You can reset your from the password reset page.',
+            })
+        ).toHaveAttribute('href', '/reset-password')
+    })
+
+    it('Shows password expired but no link to password-reset page if passwordExpired and allowAccountRecovery is false', () => {
+        useLogin.mockReturnValue({
+            login: () => {},
+            passwordExpired: true,
+            cancelTwoFA: () => {},
+        })
+        useLoginConfig.mockReturnValueOnce({
+            allowAccountRecovery: false,
+            emailConfigured: true,
+        })
+
+        render(<LoginFormContainer />)
+
+        expect(screen.getByText('Password expired')).toBeInTheDocument()
+        expect(
+            screen.queryByRole('link', {
+                name: 'You can reset your from the password reset page.',
+            })
+        ).not.toBeInTheDocument()
+    })
+
+    it('Shows password expired but no link to password-reset page if passwordExpired and emailConfigured is false', () => {
+        useLogin.mockReturnValue({
+            login: () => {},
+            passwordExpired: true,
+            cancelTwoFA: () => {},
+        })
+        useLoginConfig.mockReturnValueOnce({
+            allowAccountRecovery: true,
+            emailConfigured: false,
+        })
+
+        render(<LoginFormContainer />)
+
+        expect(screen.getByText('Password expired')).toBeInTheDocument()
+        expect(
+            screen.queryByRole('link', {
+                name: 'You can reset your from the password reset page.',
+            })
+        ).not.toBeInTheDocument()
+    })
+
+    it('Shows Account not accessible if accountInaccessible is true', () => {
+        useLogin.mockReturnValue({
+            login: () => {},
+            accountInaccessible: true,
+            cancelTwoFA: () => {},
+        })
+
+        render(<LoginFormContainer />)
+
+        expect(screen.getByText('Account not accessible')).toBeInTheDocument()
+        expect(
+            screen.getByText('Contact your system administrator.')
+        ).toBeInTheDocument()
     })
 })

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -26,6 +26,105 @@ export default function LoginPage() {
     )
 }
 
+const LoginErrors = ({
+    lngs,
+    error,
+    twoFAIncorrect,
+    passwordExpired,
+    passwordResetEnabled,
+    accountInaccessible,
+    unknownStatus,
+}) => {
+    if (error) {
+        return (
+            <FormNotice
+                title={
+                    !error?.details?.httpStatusCode ||
+                    error.details.httpStatusCode >= 500
+                        ? i18n.t('Something went wrong', {
+                              lngs,
+                          })
+                        : i18n.t('Incorrect username or password', {
+                              lngs,
+                          })
+                }
+                error
+            >
+                {(!error?.details?.httpStatusCode ||
+                    error.details.httpStatusCode >= 500) && (
+                    <span>{error?.message}</span>
+                )}
+            </FormNotice>
+        )
+    }
+
+    if (twoFAIncorrect) {
+        return (
+            <FormNotice
+                title={i18n.t('Incorrect authentication code', {
+                    lngs,
+                })}
+                error
+            />
+        )
+    }
+    if (passwordExpired) {
+        return (
+            <FormNotice
+                title={i18n.t('Password expired', {
+                    lngs,
+                })}
+                error
+            >
+                {passwordResetEnabled ? (
+                    <Link to="/reset-password">
+                        {i18n.t(
+                            'You can reset your from the password reset page.'
+                        )}
+                    </Link>
+                ) : (
+                    i18n.t('Contact your system administrator.')
+                )}
+            </FormNotice>
+        )
+    }
+    if (accountInaccessible) {
+        return (
+            <FormNotice
+                title={i18n.t('Account not accessible', {
+                    lngs,
+                })}
+                error
+            >
+                {i18n.t('Contact your system administrator.')}
+            </FormNotice>
+        )
+    }
+    if (unknownStatus) {
+        return (
+            <FormNotice
+                title={i18n.t('Something went wrong', {
+                    lngs,
+                })}
+                error
+            >
+                {i18n.t('Contact your system administrator.')}
+            </FormNotice>
+        )
+    }
+    return null
+}
+
+LoginErrors.propTypes = {
+    accountInaccessible: PropTypes.bool,
+    error: PropTypes.object,
+    lngs: PropTypes.arrayOf(PropTypes.string),
+    passwordExpired: PropTypes.bool,
+    passwordResetEnabled: PropTypes.bool,
+    twoFAIncorrect: PropTypes.bool,
+    unknownStatus: PropTypes.bool,
+}
+
 const InnerLoginForm = ({
     handleSubmit,
     formSubmitted,
@@ -161,72 +260,16 @@ const LoginForm = ({
 
     return (
         <>
-            {error && (
-                <FormNotice
-                    title={
-                        !error?.details?.httpStatusCode ||
-                        error.details.httpStatusCode >= 500
-                            ? i18n.t('Something went wrong', {
-                                  lngs,
-                              })
-                            : i18n.t('Incorrect username or password', {
-                                  lngs,
-                              })
-                    }
-                    error
-                >
-                    {(!error?.details?.httpStatusCode ||
-                        error.details.httpStatusCode >= 500) && (
-                        <span>{error?.message}</span>
-                    )}
-                </FormNotice>
-            )}
-            {twoFAIncorrect && (
-                <FormNotice
-                    title={i18n.t('Incorrect authentication code', {
-                        lngs,
-                    })}
-                    error
-                />
-            )}
-            {passwordExpired && (
-                <FormNotice
-                    title={i18n.t('Password expired', {
-                        lngs,
-                    })}
-                    error
-                >
-                    {passwordResetEnabled ? (
-                        <Link to="/reset-password">
-                            {i18n.t(
-                                'You can reset your from the password reset page.'
-                            )}
-                        </Link>
-                    ) : (
-                        i18n.t('Contact your system administrator.')
-                    )}
-                </FormNotice>
-            )}
-            {accountInaccessible && (
-                <FormNotice
-                    title={i18n.t('Account not accessible', {
-                        lngs,
-                    })}
-                    error
-                >
-                    {i18n.t('Contact your system administrator.')}
-                </FormNotice>
-            )}
-            {unknownStatus && (
-                <FormNotice
-                    title={i18n.t('Something went wrong', {
-                        lngs,
-                    })}
-                    error
-                >
-                    {i18n.t('Contact your system administrator.')}
-                </FormNotice>
-            )}
+            <LoginErrors
+                lngs={lngs}
+                error={error}
+                twoFAIncorrect={twoFAIncorrect}
+                passwordExpired={passwordExpired}
+                passwordResetEnabled={passwordResetEnabled}
+                accountInaccessible={accountInaccessible}
+                unknownStatus={unknownStatus}
+            />
+
             <ReactFinalForm.Form onSubmit={handleLogin}>
                 {({ handleSubmit }) => (
                     <InnerLoginForm

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -135,6 +135,7 @@ const LoginForm = ({
     accountInaccessible,
     passwordExpired,
     passwordResetEnabled,
+    unknownStatus,
     error,
     loading,
     setFormUserName,
@@ -216,6 +217,16 @@ const LoginForm = ({
                     {i18n.t('Contact your system administrator.')}
                 </FormNotice>
             )}
+            {unknownStatus && (
+                <FormNotice
+                    title={i18n.t('Something went wrong', {
+                        lngs,
+                    })}
+                    error
+                >
+                    {i18n.t('Contact your system administrator.')}
+                </FormNotice>
+            )}
             <ReactFinalForm.Form onSubmit={handleLogin}>
                 {({ handleSubmit }) => (
                     <InnerLoginForm
@@ -250,6 +261,7 @@ LoginForm.propTypes = {
     setFormUserName: PropTypes.func,
     twoFAIncorrect: PropTypes.bool,
     twoFAVerificationRequired: PropTypes.bool,
+    unknownStatus: PropTypes.bool,
 }
 
 // this is set up this way to isolate styling from login form logic
@@ -261,6 +273,7 @@ export const LoginFormContainer = () => {
         twoFAIncorrect,
         accountInaccessible,
         passwordExpired,
+        unknownStatus,
         error,
         loading,
     } = useLogin()
@@ -295,6 +308,7 @@ export const LoginFormContainer = () => {
                 accountInaccessible={accountInaccessible}
                 passwordExpired={passwordExpired}
                 passwordResetEnabled={allowAccountRecovery && emailConfigured}
+                unknownStatus={unknownStatus}
                 error={error}
                 loading={loading}
             />

--- a/src/pages/login.js
+++ b/src/pages/login.js
@@ -3,6 +3,7 @@ import { ReactFinalForm, InputFieldFF, Button } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState, useRef } from 'react'
 import { useForm } from 'react-final-form'
+import { Link } from 'react-router-dom'
 import {
     ApplicationNotification,
     FormContainer,
@@ -119,11 +120,11 @@ InnerLoginForm.defaultProps = {
 InnerLoginForm.propTypes = {
     cancelTwoFA: PropTypes.func.isRequired,
     handleSubmit: PropTypes.func.isRequired,
-    twoFAVerificationRequired: PropTypes.bool.isRequired,
     formSubmitted: PropTypes.bool,
     lngs: PropTypes.arrayOf(PropTypes.string),
     loading: PropTypes.bool,
     setFormUserName: PropTypes.func,
+    twoFAVerificationRequired: PropTypes.bool,
 }
 
 const LoginForm = ({
@@ -131,6 +132,9 @@ const LoginForm = ({
     cancelTwoFA,
     twoFAVerificationRequired,
     twoFAIncorrect,
+    accountInaccessible,
+    passwordExpired,
+    passwordResetEnabled,
     error,
     loading,
     setFormUserName,
@@ -184,6 +188,34 @@ const LoginForm = ({
                     error
                 />
             )}
+            {passwordExpired && (
+                <FormNotice
+                    title={i18n.t('Password expired', {
+                        lngs,
+                    })}
+                    error
+                >
+                    {passwordResetEnabled ? (
+                        <Link to="/reset-password">
+                            {i18n.t(
+                                'You can reset your from the password reset page.'
+                            )}
+                        </Link>
+                    ) : (
+                        i18n.t('Contact your system administrator.')
+                    )}
+                </FormNotice>
+            )}
+            {accountInaccessible && (
+                <FormNotice
+                    title={i18n.t('Account not accessible', {
+                        lngs,
+                    })}
+                    error
+                >
+                    {i18n.t('Contact your system administrator.')}
+                </FormNotice>
+            )}
             <ReactFinalForm.Form onSubmit={handleLogin}>
                 {({ handleSubmit }) => (
                     <InnerLoginForm
@@ -207,11 +239,14 @@ LoginForm.defaultProps = {
 }
 
 LoginForm.propTypes = {
+    accountInaccessible: PropTypes.bool,
     cancelTwoFA: PropTypes.func,
     error: PropTypes.object,
     lngs: PropTypes.arrayOf(PropTypes.string),
     loading: PropTypes.bool,
     login: PropTypes.func,
+    passwordExpired: PropTypes.bool,
+    passwordResetEnabled: PropTypes.bool,
     setFormUserName: PropTypes.func,
     twoFAIncorrect: PropTypes.bool,
     twoFAVerificationRequired: PropTypes.bool,
@@ -224,11 +259,13 @@ export const LoginFormContainer = () => {
         cancelTwoFA,
         twoFAVerificationRequired,
         twoFAIncorrect,
+        accountInaccessible,
+        passwordExpired,
         error,
         loading,
     } = useLogin()
     const [formUserName, setFormUserName] = useState('')
-    const { lngs } = useLoginConfig()
+    const { lngs, allowAccountRecovery, emailConfigured } = useLoginConfig()
 
     return (
         <FormContainer
@@ -255,6 +292,9 @@ export const LoginFormContainer = () => {
                 cancelTwoFA={cancelTwoFA}
                 twoFAVerificationRequired={twoFAVerificationRequired}
                 twoFAIncorrect={twoFAIncorrect}
+                accountInaccessible={accountInaccessible}
+                passwordExpired={passwordExpired}
+                passwordResetEnabled={allowAccountRecovery && emailConfigured}
                 error={error}
                 loading={loading}
             />

--- a/src/pages/password-reset-request.js
+++ b/src/pages/password-reset-request.js
@@ -71,7 +71,7 @@ const InnerPasswordResetRequestForm = ({
 InnerPasswordResetRequestForm.propTypes = {
     formSubmitted: PropTypes.bool,
     handleSubmit: PropTypes.func,
-    isRequired: PropTypes.bool,
+    isRequired: PropTypes.func,
     lngs: PropTypes.arrayOf(PropTypes.string),
     loading: PropTypes.bool,
 }


### PR DESCRIPTION
See https://dhis2.atlassian.net/jira/software/c/projects/DHIS2/issues/DHIS2-17773

### Summary

This PR adds in some missing statuses that can be returned from the backend when posting to api/auth/login. The backend will respond with a 200 status code in cases where user can not be authenticated, these include if 2fa was not provided (already handled by app) and if password has expired, account has been disabled, account has been locked, or account has expired (not handled by the app). Full list of statuses: https://github.com/dhis2/dhis2-core/blob/master/dhis-2/dhis-web-api/src/main/java/org/hisp/dhis/webapi/controller/security/LoginResponse.java#L48-L54

The login app currently will redirect only when you both get a 200 response and the status comes back as 'SUCCESS'. This leads to a situation where the app finishes logging in but nothing happens

For example with a disabled user:

**Before**
(login has completed, but nothing happens)
<img width="368" alt="image" src="https://github.com/user-attachments/assets/a735e357-7cbf-4938-8149-bcf096ef35f0">


**After**
(login has completed and app shows a notice box saying that the account is inaccessible)
<img width="348" alt="image" src="https://github.com/user-attachments/assets/70641699-380e-4bba-b23c-b7706459e582">

### Summary of behavior after this PR:
| status | message/UI |
| --- | ------------------------------ |
| expired password, account recovery allowed + email configured | Password expired + link to password-reset page |
| expired password, account recovery allowed / email configured is false | Password expired + contact sys admin message |
| disabled user | Account is not accessible + contact sys admin message |
| expired user | Account is not accessible + contact sys admin message |
| locked user | Account is not accessible + contact sys admin message |
| unknown status returned* | Something went wrong  + contact sys admin message |

* I guess another option here would be to try to redirect, but I'm assuming that it's unlikely that the backend is going to suddenly add an additional "success" status that would require redirect

### Testing

**Manual**: It's fairly easy to set up a disabled and an expired user, so I have manually tested those. Expired user was why I noticed this issue, so I could also manually tested that scenario:
<img width="825" alt="image" src="https://github.com/user-attachments/assets/923c5ca2-00fe-4999-ad5b-1fbabc52fbdf">
Locked user I did not test explicitly as I don't know how to lock a user. Unknown status I also did not test manually (other than testing by setting this as true in the app and checking that message appeared).

**Automated**: I've added tests for the useLogin hook that sets the status based on backend response and tests in the login.js page to make sure that messages are displaying as intended based on login status/system settings.