### PR TITLE
fix: correct for unnecessary horizontal side bar [DHIS2-17138]

### DIFF
--- a/src/templates/standard.js
+++ b/src/templates/standard.js
@@ -19,7 +19,8 @@ export const standard = `
 		    display: flex;
 		    flex-direction: column;
 		    height: 100vh;
-		    width: 100vw; 		    
+		    width: 100vw;
+		    max-width: 100%;
 		}
         .heading {
             display: flex;


### PR DESCRIPTION
This adds 'max-width: 100%' in the .app styling to prevent the appearance of a horizontal sidebar which appeared because when a vertical scrollbar was needed, the `width: 100vw` would make it such that the horizontal scrollbar was necessary to see the entire view width of the window (given that you now had window + vertical scrollbar) 

**Before**
<img width="1356" alt="image" src="https://github.com/user-attachments/assets/886d1eb4-6d97-4a6e-be74-74a4220f5c1c">


**After**
<img width="1354" alt="image" src="https://github.com/user-attachments/assets/89cad5b2-374e-449a-9d2e-9cabfb5d7908">


**Testing**
Manually tested in Chrome, Firefox, Safari, Opera. 
I didn't look into automated test as we don't usually test style details with automated tests.