### PR TITLE
fix: ignore blank string custom html [DHIS2-19400]

### DIFF
--- a/src/app.jsx
+++ b/src/app.jsx
@@ -114,7 +114,10 @@ export const AppContent = () => {
     if (loginPageLayout === 'SIDEBAR') {
         html = sidebar
     } else if (loginPageLayout === 'CUSTOM') {
-        html = loginPageTemplate ?? standard
+        html =
+            loginPageTemplate && loginPageTemplate !== ''
+                ? loginPageTemplate
+                : standard
     } else {
         html = standard
     }

--- a/src/app.test.jsx
+++ b/src/app.test.jsx
@@ -56,6 +56,15 @@ describe('AppContent', () => {
         expect(screen.getByText('STANDARD TEMPLATE')).toBeInTheDocument()
     })
 
+    it('loads standard template if loginPageLayout is CUSTOM and loginPageTemplate is empty string', () => {
+        useLoginConfig.mockReturnValue({
+            loginPageLayout: 'CUSTOM',
+            loginPageTemplate: '',
+        })
+        renderWithRouter(<AppContent />)
+        expect(screen.getByText('STANDARD TEMPLATE')).toBeInTheDocument()
+    })
+
     it('loads custom loginPageTemplate if loginPageLayout is CUSTOM and loginPageTemplate is not null', () => {
         useLoginConfig.mockReturnValue({
             loginPageLayout: 'CUSTOM',


### PR DESCRIPTION
See ticket https://dhis2.atlassian.net/browse/DHIS2-19400

This fix makes the app ignore the selection of "Custom" login page where the custom HTML is an empty string `''` (which can happen in the current settings app when you select custom form but do not provide HTML). In this case, the login app will fall back to the standard template.

(Previously, in v41, it seems the backend was returning null for loginPageTemplate in this case, hence the apparent bug from v41 to v42+; )

